### PR TITLE
wip: Refactor revision handling to enclose revisions in backticks

### DIFF
--- a/tests/test_git_message.py
+++ b/tests/test_git_message.py
@@ -178,6 +178,32 @@ Key1: Value1"""
         self.assertEqual(main_message, expected_main)
         self.assertEqual(metadata, expected_metadata)
 
+    def test_parse_message_with_backtick_revisions(self):
+        """Test parsing a commit message with backtick-enclosed revision history."""
+        message = """feat: Add feature
+
+Description
+
+```
+abcdef0  (Base revision)
+1234567  Previous commit
+HEAD  Current change
+```
+
+codemcp-id: abc-123"""
+        main_message, metadata = parse_git_commit_message(message)
+        expected_main = """feat: Add feature
+
+Description
+
+```
+abcdef0  (Base revision)
+1234567  Previous commit
+HEAD  Current change
+```"""
+        self.assertEqual(main_message, expected_main)
+        self.assertEqual(metadata, {"codemcp-id": "abc-123"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16
* #15

43a62e8  (Base revision)
7956cf6  Update first commit formatting to use backticks
708010c  Add test for parsing commit message with backtick-enclosed revisions
37f34b6  Auto-commit format changes
HEAD     Auto-commit lint changes

codemcp-id: 57-refactor-modify-commit-message-to-enclose-revision