### PR TITLE
fix: handle single-line messages correctly in append_metadata_to_message

### DIFF
--- a/codemcp/git_message.py
+++ b/codemcp/git_message.py
@@ -14,8 +14,10 @@ log = logging.getLogger(__name__)
 def append_metadata_to_message(message: str, metadata: dict) -> str:
     """Append codemcp-id to a Git commit message.
 
-    This function adds the codemcp-id to the end of a commit message with a double newline
-    separator unless the line above is a metadata line of the form key: value.
+    This function adds the codemcp-id to the end of a commit message with:
+    - A double newline separator for single-line messages (even if they contain a colon)
+    - A double newline separator for regular message content
+    - A single newline separator if the line above is a metadata line of the form key: value
 
     Args:
         message: The original Git commit message
@@ -36,8 +38,14 @@ def append_metadata_to_message(message: str, metadata: dict) -> str:
     # Split the message into lines to analyze the last line
     lines = message.splitlines()
 
-    # Check if the last line looks like a metadata line (key: value)
-    if lines and ":" in lines[-1] and not lines[-1].startswith(" "):
+    # For single-line messages (subject only), always use double newline regardless of colon
+    if len(lines) == 1:
+        if message.endswith("\n"):
+            return f"{message}\ncodemcp-id: {codemcp_id}"
+        else:
+            return f"{message}\n\ncodemcp-id: {codemcp_id}"
+    # For multi-line messages, check if the last line looks like a metadata line (key: value)
+    elif lines and ":" in lines[-1] and not lines[-1].startswith(" "):
         # If the last line looks like metadata, append without double newline
         if message.endswith("\n"):
             return f"{message}codemcp-id: {codemcp_id}"

--- a/tests/test_git_message.py
+++ b/tests/test_git_message.py
@@ -120,6 +120,14 @@ codemcp-id: new-id""",
         # Without codemcp-id, the message should be unchanged
         self.assertEqual(new_message, "feat: Add feature")
 
+    def test_single_line_subject_with_colon(self):
+        """Test handling a single-line message with a colon in the subject."""
+        message = "feat: Add new feature"
+        new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
+        # A single line with a colon should be treated as subject, not metadata
+        # The codemcp-id should be appended with a double newline
+        self.assertEqual(new_message, "feat: Add new feature\n\ncodemcp-id: abc-123")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #24
* #23

append_metadata_to_message has a bug: if the message in question is a single line only (subject only), you MUST use a double newline (because a colon in the line doesn't mean it's metadata, it must be the subject.)

```git-revs
7392f17  (Base revision)
98e77b2  Add test case for single-line message with colon in subject
c8a0758  Fix handling of single-line messages in append_metadata_to_message
e260bc5  Update docstring to clarify handling of single-line messages
HEAD     Auto-commit format changes
```

codemcp-id: 72-fix-handle-single-line-messages-correctly-in-appen