### PR TITLE
feat: add UserPrompt tool

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -51,11 +51,16 @@ async def codemcp(
     If the user indicates they want to "amend" or "continue working" on a PR,
     you should set reuse_head_chat_id=True to continue using the same chat ID.
 
+    In each response after the first one, you must call the UserPrompt tool
+    with the user's verbatim message text.
+
     Arguments:
-      subtool: The subtool to run (InitProject, ...)
+      subtool: The subtool to run (InitProject, UserPrompt, ...)
       path: The path to the file or directory to operate on
       chat_id: A unique ID to identify the chat session (provided by InitProject and required for all tools EXCEPT InitProject)
-      user_prompt: The user's original prompt verbatim (for InitProject), starting AFTER instructions to initialize codemcp (e.g., you should exclude "Initialize codemcp for PATH")
+      user_prompt: The user's original prompt verbatim:
+        - For InitProject: starting AFTER instructions to initialize codemcp (e.g., you should exclude "Initialize codemcp for PATH")
+        - For UserPrompt: the complete verbatim user message for the current round
       subject_line: A short subject line in Git conventional commit format (for InitProject)
       reuse_head_chat_id: If True, reuse the chat ID from the HEAD commit instead of generating a new one (for InitProject)
       ... (there are other arguments which are documented later)
@@ -80,6 +85,7 @@ async def codemcp(
             "subject_line",
             "reuse_head_chat_id",
         },  # chat_id is not expected for InitProject as it's generated there
+        "UserPrompt": {"user_prompt", "chat_id"},
         "RunCommand": {"path", "command", "arguments", "chat_id"},
         "Grep": {"pattern", "path", "include", "chat_id"},
         "Glob": {"pattern", "path", "limit", "offset", "chat_id"},
@@ -232,6 +238,12 @@ async def codemcp(
                 f"Exception suppressed in glob subtool: {e!s}", exc_info=True
             )
             return f"Error executing glob: {e!s}"
+
+    if subtool == "UserPrompt":
+        if user_prompt is None:
+            return "Error: user_prompt is required for UserPrompt subtool"
+
+        return await user_prompt(user_prompt, chat_id)
 
 
 def configure_logging(log_file="codemcp.log"):

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -58,9 +58,7 @@ async def codemcp(
       subtool: The subtool to run (InitProject, UserPrompt, ...)
       path: The path to the file or directory to operate on
       chat_id: A unique ID to identify the chat session (provided by InitProject and required for all tools EXCEPT InitProject)
-      user_prompt: The user's original prompt verbatim:
-        - For InitProject: starting AFTER instructions to initialize codemcp (e.g., you should exclude "Initialize codemcp for PATH")
-        - For UserPrompt: the complete verbatim user message for the current round
+      user_prompt: The user's original prompt verbatim, starting AFTER instructions to initialize codemcp (e.g., you should exclude "Initialize codemcp for PATH")
       subject_line: A short subject line in Git conventional commit format (for InitProject)
       reuse_head_chat_id: If True, reuse the chat ID from the HEAD commit instead of generating a new one (for InitProject)
       ... (there are other arguments which are documented later)

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -343,6 +343,12 @@ If you want to create a new file, use:
 
 Remember: when making multiple file edits in a row to the same file, you should prefer to send all edits in a single message with multiple calls to this tool, rather than multiple messages with a single call each.
 
+## UserPrompt chat_id user_prompt
+
+Records the user's verbatim prompt text for each interaction after the initial one.
+You should call this tool with the user's exact message at the beginning of each response.
+This tool must be called in every response except for the first one where InitProject was used.
+
 ## LS chat_id path
 
 Lists files and directories in a given path. The path parameter must be an absolute path, not a relative path. You should generally prefer the Glob and Grep tools, if you know which directories to search.
@@ -373,7 +379,7 @@ with this set of valid commands: {command_help}
 ## Summary
 
 Args:
-    subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, RunCommand)
+    subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, UserPrompt, RunCommand)
     path: The path to the file or directory to operate on
     content: Content for WriteFile subtool
     old_string: String to replace for EditFile subtool
@@ -382,6 +388,7 @@ Args:
     limit: Line limit for ReadFile subtool
     description: Short description of the change (for WriteFile/EditFile)
     arguments: A list of string arguments for RunCommand subtool
+    user_prompt: The user's verbatim text (for UserPrompt subtool)
     chat_id: A unique ID to identify the chat session (required for all tools EXCEPT InitProject)
 
 # Chat ID

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import logging
+
+__all__ = [
+    "user_prompt",
+]
+
+
+async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
+    """Store the user's verbatim prompt text for later use.
+
+    This function currently does nothing but may be extended in the future
+    to store the prompt text for inclusion in commit messages.
+
+    Args:
+        user_text: The user's original prompt verbatim
+        chat_id: The unique ID of the current chat session
+
+    Returns:
+        A confirmation message
+    """
+    try:
+        logging.info(f"Received user prompt for chat ID {chat_id}: {user_text}")
+        # For now, this is just a placeholder that returns a confirmation
+        # In the future, this might store the text for use in commit messages
+        return "User prompt received"
+    except Exception as e:
+        logging.warning(f"Exception suppressed in user_prompt: {e!s}", exc_info=True)
+        return f"Error processing user prompt: {e!s}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #28
* __->__ #26

Let's add a new tool UserPrompt. This tool should always be called with the verbatim user text every round (except for the very first one, which is handled by InitProject). It should use the same user_prompt argument that InitProject takes. For now, the tool doesn't have to do anything (but later, we will amend this prompt text into the commit message.

```git-revs
ace6050  (Base revision)
20bb268  Create UserPrompt tool implementation
b18b19e  Import user_prompt tool
560f017  Add UserPrompt to expected parameters
4a2da39  Add UserPrompt handler
6cf6492  Add UserPrompt tool documentation to system prompt
9e17598  Update tool docstring to mention UserPrompt
0dd7bb0  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 75-feat-add-userprompt-tool