### PR TITLE
fix: analyze git_message.py bug with START_MARKER and END_MARKER

### DIFF
--- a/codemcp/git_message.py
+++ b/codemcp/git_message.py
@@ -234,33 +234,6 @@ def update_commit_message_with_description(
                     # No commit hash, but we should still use the START_MARKER and END_MARKER
                     # Create a single entry with just the description
                     rev_entries = [f"HEAD  {description}"]
-                    formatted_rev_list = "\n".join(rev_entries)
-
-                    # Add formatted revision list with markers to the message
-                    if main_message:
-                        # Ensure proper spacing
-                        if main_message.endswith("\n\n"):
-                            main_message += (
-                                f"{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                            )
-                        elif main_message.endswith("\n"):
-                            main_message += (
-                                f"\n{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                            )
-                        else:
-                            main_message += f"\n\n{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                    else:
-                        main_message = (
-                            f"{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                        )
-
-                    # Ensure the chat ID metadata is included if provided
-                    if chat_id:
-                        return append_metadata_to_message(
-                            main_message, {"codemcp-id": chat_id}
-                        )
-                    else:
-                        return main_message
 
                 # Format the revision list with markers
                 formatted_rev_list = "\n".join(rev_entries)

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -204,24 +204,6 @@ async def init_project(
                 chat_id=chat_id,
             )
 
-            # Ensure the revisions are within the markers
-            # Add the lines directly into the markers
-            import re
-
-            def ensure_markers_have_content(message):
-                # Look for the pattern ```git-revs followed by empty or whitespace, then ```
-                pattern = r"```git-revs\s*```"
-                if re.search(pattern, message):
-                    # If markers are empty, put HEAD entry inside
-                    with_content = re.sub(
-                        pattern, f"```git-revs\nHEAD  {subject_line}\n```", message
-                    )
-                    return with_content
-                return message
-
-            # Make sure our markers have content
-            commit_msg = ensure_markers_have_content(commit_msg)
-
             # Create a commit reference instead of creating a regular commit
             # This will not advance HEAD but store the commit in refs/codemcp/<chat_id>
             success, message, commit_hash = await create_commit_reference(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #35
* __->__ #34
* #32
* #30
* #29

There's a bug in git_message.py regarding START_MARKER and END_MARKER tokens. Specifically, on the very first time we make a write (and insert our first git-revs list; previously there was none), we don't properly put it start/end markers.

codemcp-id: 83-fix-analyze-git-message-py-bug-with-start-marker-a

```git-revs
6b73798  (Base revision)
3cedb8f  Fix bug in update_commit_message_with_description by removing duplicated code branch
HEAD     Remove ensure_markers_have_content workaround as it's no longer needed
```