### PR TITLE
test: update test_git_message to use expecttest

### DIFF
--- a/tests/test_git_message.py
+++ b/tests/test_git_message.py
@@ -1,24 +1,30 @@
 #!/usr/bin/env python3
 
 import unittest
+from expecttest import TestCase
 from codemcp.git import append_metadata_to_message
 
 
-class TestGitMessageHandling(unittest.TestCase):
+class TestGitMessageHandling(TestCase):
     """Test cases for Git commit message metadata handling."""
 
     def test_append_empty_message(self):
         """Test appending metadata to an empty message."""
         message = ""
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
-        self.assertEqual(new_message, "codemcp-id: abc-123")
+        self.assertExpectedInline(new_message, """codemcp-id: abc-123""")
 
     def test_append_new_metadata(self):
         """Test appending new metadata to a message without existing metadata."""
         message = "feat: Add feature\n\nDescription"
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
-        self.assertEqual(
-            new_message, "feat: Add feature\n\nDescription\n\ncodemcp-id: abc-123"
+        self.assertExpectedInline(
+            new_message,
+            """feat: Add feature
+
+Description
+
+codemcp-id: abc-123""",
         )
 
     def test_append_to_existing_metadata(self):
@@ -29,7 +35,7 @@ Description
 
 Signed-off-by: User <user@example.com>"""
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
-        self.assertEqual(
+        self.assertExpectedInline(
             new_message,
             """feat: Add feature
 
@@ -48,7 +54,7 @@ Description
 Signed-off-by: User <user@example.com>
 """
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
-        self.assertEqual(
+        self.assertExpectedInline(
             new_message,
             """feat: Add feature
 
@@ -66,7 +72,7 @@ Description
 
 """
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
-        self.assertEqual(
+        self.assertExpectedInline(
             new_message,
             """feat: Add feature
 
@@ -84,7 +90,7 @@ Description
 
 """
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
-        self.assertEqual(
+        self.assertExpectedInline(
             new_message,
             """feat: Add feature
 
@@ -103,7 +109,7 @@ Description
 codemcp-id: old-id"""
         new_message = append_metadata_to_message(message, {"codemcp-id": "new-id"})
         # With our new implementation, we just append the new ID at the end
-        self.assertEqual(
+        self.assertExpectedInline(
             new_message,
             """feat: Add feature
 
@@ -118,7 +124,7 @@ codemcp-id: new-id""",
         message = "feat: Add feature"
         new_message = append_metadata_to_message(message, {"other-key": "value"})
         # Without codemcp-id, the message should be unchanged
-        self.assertEqual(new_message, "feat: Add feature")
+        self.assertExpectedInline(new_message, """feat: Add feature""")
 
     def test_single_line_subject_with_colon(self):
         """Test handling a single-line message with a colon in the subject."""
@@ -126,7 +132,12 @@ codemcp-id: new-id""",
         new_message = append_metadata_to_message(message, {"codemcp-id": "abc-123"})
         # A single line with a colon should be treated as subject, not metadata
         # The codemcp-id should be appended with a double newline
-        self.assertEqual(new_message, "feat: Add new feature\n\ncodemcp-id: abc-123")
+        self.assertExpectedInline(
+            new_message,
+            """feat: Add new feature
+
+codemcp-id: abc-123""",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #38
* #37
* #36

Update **tests/test_git_message.py** to use expecttest. This is the first time we're adding expecttest for a unit test, so no need to read other files for context. expecttest is already installed so you don't need to check for it.

```git-revs
fbf9341  (Base revision)
5ffd654  Replace unittest.TestCase with expecttest.TestCase
a47e171  Convert test_append_empty_message to use assertExpectedInline
8eab4e2  Convert test_append_new_metadata to use assertExpectedInline
aaa6f97  Convert test_append_to_existing_metadata to use assertExpectedInline
a11b6a7  Convert test_append_to_existing_metadata_with_trailing_newline to use assertExpectedInline
449fee7  Convert test_append_to_message_with_trailing_newlines to use assertExpectedInline
ad768c1  Convert test_append_to_message_with_double_trailing_newlines to use assertExpectedInline
e21a011  Convert test_update_existing_metadata to use assertExpectedInline
971c5ac  Convert test_meta_ignored_except_codemcp_id to use assertExpectedInline
85ab2dd  Convert test_single_line_subject_with_colon to use assertExpectedInline
HEAD     Auto-commit format changes
```

codemcp-id: 93-test-update-test-git-message-to-use-expecttest