### PR TITLE
test: add commit message verification to write file test

### DIFF
--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -92,6 +92,26 @@ nothing to commit, working tree clean
 """,
             )
 
+            # Get the commit message of the HEAD commit
+            commit_message = (
+                subprocess.check_output(
+                    ["git", "log", "-1", "--pretty=%B"],
+                    cwd=self.temp_dir.name,
+                    env=self.env,
+                )
+                .decode()
+                .strip()
+            )
+
+            # Use expect test to verify the commit message
+            self.assertExpectedInline(
+                commit_message,
+                """\
+wip: Create new file
+
+codemcp-id: test-chat-id""",
+            )
+
     async def test_create_new_file_with_write_file(self):
         """Test creating a new file that doesn't exist yet with WriteFile."""
         # Path to a new file that doesn't exist yet, within the git repository


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #45
* #44
* #43
* #42
* #41
* __->__ #40

In **e2e/test_write_file.py** in test_write_file modify the test to test the commit message of the HEAD commit after the WriteFile command. Use expecttest to display the message.

```git-revs
6dafb86  (Base revision)
9d8dd7a  Add commit message verification to test_write_file
11e9fe9  Auto-commit accept changes
HEAD     Auto-commit format changes
```

codemcp-id: 95-test-add-commit-message-verification-to-write-file