### PR TITLE
wip: Remove default values for required parameters in init_project function signature

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -44,8 +44,7 @@ async def codemcp(
     | None = None,  # Whether to reuse the chat ID from the HEAD commit
 ) -> str:
     """If and only if the user explicitly asks you to initialize codemcp with
-    path, you should invoke this tool with arguments `InitProject
-    path`.  This will return instructions which you should
+    path, you should invoke this tool.  This will return instructions which you should
     IMMEDIATELY follow before continuing.
 
     If the user indicates they want to "amend" or "continue working" on a PR,
@@ -177,6 +176,14 @@ async def codemcp(
     if subtool == "InitProject":
         if path is None:
             return "Error: path is required for InitProject subtool"
+        if user_prompt is None:
+            return "Error: user_prompt is required for InitProject subtool"
+        if subject_line is None:
+            return "Error: subject_line is required for InitProject subtool"
+        if reuse_head_chat_id is None:
+            reuse_head_chat_id = (
+                False  # Default value in main.py only, not in the implementation
+            )
 
         return await init_project(path, user_prompt, subject_line, reuse_head_chat_id)
 

--- a/codemcp/multi_entry.py
+++ b/codemcp/multi_entry.py
@@ -48,8 +48,14 @@ async def grep(
 
 
 @mcp.tool()
-async def init_project_tool(ctx: Context, file_path: str) -> str:
-    return await init_project(file_path)
+async def init_project_tool(
+    ctx: Context,
+    file_path: str,
+    user_prompt: str,
+    subject_line: str,
+    reuse_head_chat_id: bool = False,
+) -> str:
+    return await init_project(file_path, user_prompt, subject_line, reuse_head_chat_id)
 
 
 def main():

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -129,7 +129,13 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         # First initialize project to get chat_id
         init_result = await session.call_tool(
             "codemcp",
-            {"subtool": "InitProject", "path": self.temp_dir.name},
+            {
+                "subtool": "InitProject", 
+                "path": self.temp_dir.name,
+                "user_prompt": "Test initialization for get_chat_id",
+                "subject_line": "test: initialize for e2e testing",
+                "reuse_head_chat_id": False,
+            },
         )
         init_result_text = self.extract_text_from_result(init_result)
 

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -121,9 +121,9 @@ async def _generate_chat_id(directory: str, description: str = None) -> str:
 
 async def init_project(
     directory: str,
-    user_prompt: str = None,
-    subject_line: str = None,
-    reuse_head_chat_id: bool = False,
+    user_prompt: str,
+    subject_line: str,
+    reuse_head_chat_id: bool,
 ) -> str:
     """Initialize a project by reading the codemcp.toml TOML file and returning
     a combined system prompt. Creates an empty commit with the user's prompt as the body
@@ -131,9 +131,9 @@ async def init_project(
 
     Args:
         directory: The directory path containing the codemcp.toml file
-        user_prompt: The user's original prompt verbatim (optional)
-        subject_line: A short subject line in Git conventional commit format (optional)
-        reuse_head_chat_id: Whether to reuse the chat ID from the HEAD commit (optional)
+        user_prompt: The user's original prompt verbatim
+        subject_line: A short subject line in Git conventional commit format
+        reuse_head_chat_id: Whether to reuse the chat ID from the HEAD commit
 
     Returns:
         A string containing the system prompt plus any project_prompt from the config,
@@ -182,26 +182,25 @@ async def init_project(
         if not chat_id:
             chat_id = await _generate_chat_id(full_dir_path, subject_line)
 
-        # Create an empty commit with user prompt and subject line if provided
-        if user_prompt is not None and subject_line is not None:
-            from ..git import create_commit_reference
+        # Create an empty commit with user prompt and subject line
+        from ..git import create_commit_reference
 
-            # We already validated that we're in a git repository
-            # Format the commit message according to the specified format
-            commit_body = user_prompt
-            commit_msg = f"{subject_line}\n\n{commit_body}\n\ncodemcp-id: {chat_id}"
+        # We already validated that we're in a git repository
+        # Format the commit message according to the specified format
+        commit_body = user_prompt
+        commit_msg = f"{subject_line}\n\n{commit_body}\n\ncodemcp-id: {chat_id}"
 
-            # Create a commit reference instead of creating a regular commit
-            # This will not advance HEAD but store the commit in refs/codemcp/<chat_id>
-            success, message, commit_hash = await create_commit_reference(
-                full_dir_path,
-                description=subject_line,
-                chat_id=chat_id,
-                custom_message=commit_msg,
-            )
+        # Create a commit reference instead of creating a regular commit
+        # This will not advance HEAD but store the commit in refs/codemcp/<chat_id>
+        success, message, commit_hash = await create_commit_reference(
+            full_dir_path,
+            description=subject_line,
+            chat_id=chat_id,
+            custom_message=commit_msg,
+        )
 
-            if not success:
-                logging.warning(f"Failed to create commit reference: {message}")
+        if not success:
+            logging.warning(f"Failed to create commit reference: {message}")
 
         project_prompt = ""
         command_help = ""

--- a/e2e/test_init_project.py
+++ b/e2e/test_init_project.py
@@ -142,6 +142,9 @@ test = ["./run_test.sh"]
                 {
                     "subtool": "InitProject",
                     "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization",
+                    "subject_line": "feat: test basic functionality",
+                    "reuse_head_chat_id": False,
                 },
             )
 
@@ -180,6 +183,9 @@ doc = "Run tests with optional arguments"
                 {
                     "subtool": "InitProject",
                     "path": self.temp_dir.name,
+                    "user_prompt": "Test with complex TOML",
+                    "subject_line": "feat: test complex TOML parsing",
+                    "reuse_head_chat_id": False,
                 },
             )
 
@@ -211,6 +217,9 @@ format = ["./run_format.sh"]
                 {
                     "subtool": "InitProject",
                     "path": self.temp_dir.name,
+                    "user_prompt": "Test with binary characters",
+                    "subject_line": "feat: test binary character handling",
+                    "reuse_head_chat_id": False,
                 },
             )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #45
* #44
* #43
* #42
* __->__ #41
* #40

```git-revs
0f0a636  (Base revision)
5b094f1  Update docstring to remove the (optional) notation from required parameters
f1e5c40  Remove conditional check on user_prompt and subject_line since they are now required
5103e76  Add parameter validation for required InitProject parameters in main.py
e8a6864  Update init_project_tool in multi_entry.py to pass required parameters
d4cc130  Update test_init_project_basic test to pass required parameters
c40a45b  Update test_init_project_complex_toml test to pass required parameters
ec6f3c3  Update test_init_project_with_binary_characters test to pass required parameters
53007f7  Fix indentation in init_project.py
HEAD     Snapshot before auto-format
```

codemcp-id: 96-refactor-remove-default-values-for-required-params