### PR TITLE
refactor: convert string errors to exception raising

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -90,7 +90,9 @@ async def codemcp(
 
     # Check if subtool exists
     if subtool not in expected_params:
-        return f"Unknown subtool: {subtool}. Available subtools: {', '.join(expected_params.keys())}"
+        raise ValueError(
+            f"Unknown subtool: {subtool}. Available subtools: {', '.join(expected_params.keys())}"
+        )
 
     # Handle string arguments - convert to a list with one element
     if isinstance(arguments, str):
@@ -128,36 +130,40 @@ async def codemcp(
     # Check for unexpected parameters
     unexpected_params = set(provided_params.keys()) - expected_params[subtool]
     if unexpected_params:
-        return f"Error: Unexpected parameters for {subtool} subtool: {', '.join(unexpected_params)}"
+        raise ValueError(
+            f"Unexpected parameters for {subtool} subtool: {', '.join(unexpected_params)}"
+        )
 
     # Check for required chat_id for all tools except InitProject
     if subtool != "InitProject" and chat_id is None:
-        return f"Error: chat_id is required for {subtool} subtool"
+        raise ValueError(f"chat_id is required for {subtool} subtool")
 
     # Now handle each subtool with its expected parameters
     if subtool == "ReadFile":
         if path is None:
-            return "Error: path is required for ReadFile subtool"
+            raise ValueError("path is required for ReadFile subtool")
 
         return await read_file_content(path, offset, limit, chat_id)
 
     if subtool == "WriteFile":
         if path is None:
-            return "Error: path is required for WriteFile subtool"
+            raise ValueError("path is required for WriteFile subtool")
         if description is None:
-            return "Error: description is required for WriteFile subtool"
+            raise ValueError("description is required for WriteFile subtool")
 
         content_str = content or ""
         return await write_file_content(path, content_str, description, chat_id)
 
     if subtool == "EditFile":
         if path is None:
-            return "Error: path is required for EditFile subtool"
+            raise ValueError("path is required for EditFile subtool")
         if description is None:
-            return "Error: description is required for EditFile subtool"
+            raise ValueError("description is required for EditFile subtool")
         if old_string is None and old_str is None:
             # TODO: I want telemetry to tell me when this occurs.
-            return "Error: Either old_string or old_str is required for EditFile subtool (use empty string for new file creation)"
+            raise ValueError(
+                "Either old_string or old_str is required for EditFile subtool (use empty string for new file creation)"
+            )
 
         # Accept either old_string or old_str (prefer old_string if both are provided)
         old_content = old_string or old_str or ""
@@ -169,17 +175,17 @@ async def codemcp(
 
     if subtool == "LS":
         if path is None:
-            return "Error: path is required for LS subtool"
+            raise ValueError("path is required for LS subtool")
 
         return await ls_directory(path, chat_id)
 
     if subtool == "InitProject":
         if path is None:
-            return "Error: path is required for InitProject subtool"
+            raise ValueError("path is required for InitProject subtool")
         if user_prompt is None:
-            return "Error: user_prompt is required for InitProject subtool"
+            raise ValueError("user_prompt is required for InitProject subtool")
         if subject_line is None:
-            return "Error: subject_line is required for InitProject subtool"
+            raise ValueError("subject_line is required for InitProject subtool")
         if reuse_head_chat_id is None:
             reuse_head_chat_id = (
                 False  # Default value in main.py only, not in the implementation
@@ -194,18 +200,18 @@ async def codemcp(
         # not to conflict with codemcp's subtools.
 
         if path is None:
-            return "Error: path is required for RunCommand subtool"
+            raise ValueError("path is required for RunCommand subtool")
         if command is None:
-            return "Error: command is required for RunCommand subtool"
+            raise ValueError("command is required for RunCommand subtool")
 
         return await run_command(path, command, arguments, chat_id)
 
     if subtool == "Grep":
         if pattern is None:
-            return "Error: pattern is required for Grep subtool"
+            raise ValueError("pattern is required for Grep subtool")
 
         if path is None:
-            return "Error: path is required for Grep subtool"
+            raise ValueError("path is required for Grep subtool")
 
         try:
             result = await grep_files(pattern, path, include, chat_id)
@@ -221,10 +227,10 @@ async def codemcp(
 
     if subtool == "Glob":
         if pattern is None:
-            return "Error: pattern is required for Glob subtool"
+            raise ValueError("pattern is required for Glob subtool")
 
         if path is None:
-            return "Error: path is required for Glob subtool"
+            raise ValueError("path is required for Glob subtool")
 
         try:
             result = await glob_files(
@@ -246,7 +252,7 @@ async def codemcp(
 
     if subtool == "UserPrompt":
         if user_prompt is None:
-            return "Error: user_prompt is required for UserPrompt subtool"
+            raise ValueError("user_prompt is required for UserPrompt subtool")
 
         return await user_prompt(user_prompt, chat_id)
 

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -130,7 +130,7 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         init_result = await session.call_tool(
             "codemcp",
             {
-                "subtool": "InitProject", 
+                "subtool": "InitProject",
                 "path": self.temp_dir.name,
                 "user_prompt": "Test initialization for get_chat_id",
                 "subject_line": "test: initialize for e2e testing",

--- a/codemcp/tools/code_command.py
+++ b/codemcp/tools/code_command.py
@@ -121,10 +121,10 @@ async def run_code_command(
         full_dir_path = normalize_file_path(project_dir)
 
         if not os.path.exists(full_dir_path):
-            return f"Error: Directory does not exist: {project_dir}"
+            raise FileNotFoundError(f"Directory does not exist: {project_dir}")
 
         if not os.path.isdir(full_dir_path):
-            return f"Error: Path is not a directory: {project_dir}"
+            raise NotADirectoryError(f"Path is not a directory: {project_dir}")
 
         if not command:
             # Map the command_name to keep backward compatibility with existing tests
@@ -134,7 +134,7 @@ async def run_code_command(
             elif command_name == "formatting":
                 command_key = "format"
 
-            return f"Error: No {command_key} command configured in codemcp.toml"
+            raise ValueError(f"No {command_key} command configured in codemcp.toml")
 
         # Check if directory is in a git repository
         is_git_repo = await is_git_repository(full_dir_path)

--- a/codemcp/tools/file_utils.py
+++ b/codemcp/tools/file_utils.py
@@ -28,12 +28,12 @@ async def check_file_path_and_permissions(file_path: str) -> tuple[bool, str | N
     """
     # Check that the path is absolute
     if not os.path.isabs(file_path):
-        return False, f"Error: File path must be absolute, not relative: {file_path}"
+        return False, f"File path must be absolute, not relative: {file_path}"
 
     # Check if we have permission to edit this file
     is_permitted, permission_message = await check_edit_permission(file_path)
     if not is_permitted:
-        return False, f"Error: {permission_message}"
+        return False, permission_message
 
     return True, None
 

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -146,10 +146,10 @@ async def init_project(
 
         # Validate the directory path
         if not os.path.exists(full_dir_path):
-            return f"Error: Directory does not exist: {directory}"
+            raise FileNotFoundError(f"Directory does not exist: {directory}")
 
         if not os.path.isdir(full_dir_path):
-            return f"Error: Path is not a directory: {directory}"
+            raise NotADirectoryError(f"Path is not a directory: {directory}")
 
         # Check if the directory is a Git repository
         is_git_repo = await is_git_repository(full_dir_path)
@@ -160,11 +160,17 @@ async def init_project(
 
         # If validation fails, return appropriate error messages
         if not is_git_repo and not has_codemcp_toml:
-            return f"Error: The directory is not a valid codemcp project. Please initialize a Git repository with 'git init' and create a codemcp.toml file with 'touch codemcp.toml'."
+            raise ValueError(
+                f"The directory is not a valid codemcp project. Please initialize a Git repository with 'git init' and create a codemcp.toml file with 'touch codemcp.toml'."
+            )
         elif not is_git_repo:
-            return f"Error: The directory is not a Git repository. Please initialize it with 'git init'."
+            raise ValueError(
+                f"The directory is not a Git repository. Please initialize it with 'git init'."
+            )
         elif not has_codemcp_toml:
-            return f"Error: The directory does not contain a codemcp.toml file. Please create one with 'touch codemcp.toml'."
+            raise ValueError(
+                f"The directory does not contain a codemcp.toml file. Please create one with 'touch codemcp.toml'."
+            )
 
         # If reuse_head_chat_id is True, try to get the chat ID from the HEAD commit
         chat_id = None
@@ -235,7 +241,7 @@ async def init_project(
                 f"Exception suppressed when reading codemcp.toml: {e!s}",
                 exc_info=True,
             )
-            return f"Error reading codemcp.toml file: {e!s}"
+            raise ValueError(f"Error reading codemcp.toml file: {e!s}")
 
         # Default system prompt, cribbed from claude code
         # TODO: Figure out if we want Sonnet to make determinations about what

--- a/codemcp/tools/ls.py
+++ b/codemcp/tools/ls.py
@@ -39,21 +39,21 @@ async def ls_directory(directory_path: str, chat_id: str | None = None) -> str:
 
         # Validate the directory path
         if not os.path.exists(full_directory_path):
-            return f"Error: Directory does not exist: {directory_path}"
+            raise FileNotFoundError(f"Directory does not exist: {directory_path}")
 
         if not os.path.isdir(full_directory_path):
-            return f"Error: Path is not a directory: {directory_path}"
+            raise NotADirectoryError(f"Path is not a directory: {directory_path}")
 
         # Safety check: Verify the directory is within a git repository with codemcp.toml
         if not await is_git_repository(full_directory_path):
-            return f"Error: Directory is not in a Git repository: {directory_path}"
+            raise ValueError(f"Directory is not in a Git repository: {directory_path}")
 
         # Check edit permission (which verifies codemcp.toml exists)
         is_permitted, permission_message = await check_edit_permission(
             full_directory_path
         )
         if not is_permitted:
-            return f"Error: {permission_message}"
+            raise ValueError(permission_message)
 
         # Get the directory contents asynchronously
         results = await list_directory(full_directory_path)

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -39,15 +39,17 @@ async def read_file_content(
         # Validate the file path
         if not os.path.exists(full_file_path):
             # Try to find a similar file (stub - would need implementation)
-            return f"Error: File does not exist: {file_path}"
+            raise FileNotFoundError(f"File does not exist: {file_path}")
 
         if os.path.isdir(full_file_path):
-            return f"Error: Path is a directory, not a file: {file_path}"
+            raise IsADirectoryError(f"Path is a directory, not a file: {file_path}")
 
         # Check file size before reading
         file_size = os.path.getsize(full_file_path)
         if file_size > MAX_OUTPUT_SIZE and not offset and not limit:
-            return f"Error: File content ({file_size // 1024}KB) exceeds maximum allowed size ({MAX_OUTPUT_SIZE // 1024}KB). Please use offset and limit parameters to read specific portions of the file."
+            raise ValueError(
+                f"File content ({file_size // 1024}KB) exceeds maximum allowed size ({MAX_OUTPUT_SIZE // 1024}KB). Please use offset and limit parameters to read specific portions of the file."
+            )
 
         # Handle text files - use async file operations with anyio
         from .async_file_utils import async_readlines
@@ -64,7 +66,9 @@ async def read_file_content(
 
         # Apply offset and limit
         if line_offset >= total_lines:
-            return f"Error: Offset {offset} is beyond the end of the file (total lines: {total_lines})"
+            raise IndexError(
+                f"Offset {offset} is beyond the end of the file (total lines: {total_lines})"
+            )
 
         max_lines = MAX_LINES_TO_READ if limit is None else limit
         selected_lines = all_lines[line_offset : line_offset + max_lines]

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -107,12 +107,12 @@ async def write_file_content(
         # Validate file path and permissions
         is_valid, error_message = await check_file_path_and_permissions(file_path)
         if not is_valid:
-            return error_message
+            raise ValueError(error_message)
 
         # Check git tracking for existing files
         is_tracked, track_error = await check_git_tracking_for_existing_file(file_path)
         if not is_tracked:
-            return f"Error: {track_error}"
+            raise ValueError(track_error)
 
         # Determine encoding and line endings
         old_file_exists = os.path.exists(file_path)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #45
* #44
* #43
* __->__ #42
* #41
* #40

I want to convert all of our "return a string error" in the codebase to instead raise errors. Please select an appropriate built in Python exception type for errors. Start with main.py.

```git-revs
43deebb  (Base revision)
c03b20f  Convert string error to ValueError for unknown subtool
5406cd1  Convert string error to ValueError for unexpected parameters
1c0f4d9  Convert string error to ValueError for missing chat_id
b336762  Convert string error to ValueError for ReadFile missing path
c8aa8ac  Convert string errors to ValueError for WriteFile missing parameters
df59894  Convert string errors to ValueError for EditFile missing parameters
249a483  Convert string error to ValueError for LS missing path
613004a  Convert string errors to ValueError for InitProject missing parameters
47e509d  Convert string errors to ValueError for RunCommand missing parameters
29ab290  Convert string errors to ValueError for Grep missing parameters
481ac7d  Convert string errors to ValueError for Glob missing parameters
a59ff96  Convert string error to ValueError for UserPrompt missing parameter
1076560  Convert string error to ValueError for git tracking errors
4c37c52  Convert string error to FileExistsError for existing file creation
8a23ec7  Convert string error to FileNotFoundError for missing files
f2aa900  Convert string error to ValueError for Jupyter notebook files
c30e349  Convert string error to ValueError for unread files
c773a58  Convert string error to ValueError for modified files
cfc6082  Convert string error to ValueError for string not found
c14fae2  Convert string error to ValueError for multiple string matches
e98ea5a  Convert string error to ValueError for multiple string matches in dotdotdots
HEAD     Auto-commit format changes
```

codemcp-id: 97-refactor-convert-string-errors-to-exception-raisin