### PR TITLE
fix: resolve user_prompt variable shadowing issue

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -11,7 +11,7 @@ from .tools.grep import grep_files
 from .tools.init_project import init_project
 from .tools.ls import ls_directory
 from .tools.read_file import read_file_content
-from .tools.run_command import run_command
+from .tools.user_prompt import user_prompt as user_prompt_tool
 from .tools.write_file import write_file_content
 
 # Initialize FastMCP server
@@ -254,7 +254,7 @@ async def codemcp(
         if user_prompt is None:
             raise ValueError("user_prompt is required for UserPrompt subtool")
 
-        return await user_prompt(user_prompt, chat_id)
+        return await user_prompt_tool(user_prompt, chat_id)
 
 
 def configure_logging(log_file="codemcp.log"):

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -11,6 +11,7 @@ from .tools.grep import grep_files
 from .tools.init_project import init_project
 from .tools.ls import ls_directory
 from .tools.read_file import read_file_content
+from .tools.run_command import run_command
 from .tools.user_prompt import user_prompt as user_prompt_tool
 from .tools.write_file import write_file_content
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #45
* #44
* __->__ #43
* #42
* #41
* #40

There's a small bug in main.py: user_prompt shadows the tool user_prompt so str is not callable.

```git-revs
55d649e  (Base revision)
0315a0d  Rename imported user_prompt function to avoid variable shadowing
HEAD     Update function call to use renamed import instead of shadowed parameter
```

codemcp-id: 103-fix-resolve-user-prompt-variable-shadowing-issue