### PR TITLE
refactor(tests): update test_security.py to use call_tool_assert_success helper

### DIFF
--- a/e2e/test_directory_creation.py
+++ b/e2e/test_directory_creation.py
@@ -31,7 +31,8 @@ class DirectoryCreationTest(MCPEndToEndTestCase):
             chat_id = await self.get_chat_id(session)
 
             # Call the WriteFile tool with chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "WriteFile",
@@ -42,25 +43,19 @@ class DirectoryCreationTest(MCPEndToEndTestCase):
                 },
             )
 
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
+            # Check for success message
+            self.assertIn("Successfully wrote to", result_text)
 
-            # Check for success or permission error - base directories might not be in git
-            if "Successfully wrote to" in result_text:
-                # Test passed - the directories were created as expected
-                self.assertTrue(
-                    os.path.exists(nested_path), "Nested directories were not created"
-                )
+            # Verify the directories were created as expected
+            self.assertTrue(
+                os.path.exists(nested_path), "Nested directories were not created"
+            )
 
-                # Verify the file was created with the correct content
-                self.assertTrue(os.path.exists(test_file_path), "File was not created")
-                with open(test_file_path) as f:
-                    file_content = f.read()
-                self.assertEqual(file_content, content)
-            else:
-                # Unexpected error
-                self.fail(f"Unexpected error: {result_text}")
+            # Verify the file was created with the correct content
+            self.assertTrue(os.path.exists(test_file_path), "File was not created")
+            with open(test_file_path) as f:
+                file_content = f.read()
+            self.assertEqual(file_content, content)
 
     async def test_edit_file_nested_directories(self):
         """Test EditFile can create nested directories when old_string is empty."""
@@ -80,7 +75,8 @@ class DirectoryCreationTest(MCPEndToEndTestCase):
             chat_id = await self.get_chat_id(session)
 
             # Call the EditFile tool with empty old_string and chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "EditFile",
@@ -92,25 +88,19 @@ class DirectoryCreationTest(MCPEndToEndTestCase):
                 },
             )
 
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
+            # Check for success message
+            self.assertIn("Successfully created", result_text)
 
-            # Check for success or permission error - base directories might not be in git
-            if "Successfully created" in result_text:
-                # Test passed - the directories were created as expected
-                self.assertTrue(
-                    os.path.exists(nested_path), "Nested directories were not created"
-                )
+            # Verify the directories were created as expected
+            self.assertTrue(
+                os.path.exists(nested_path), "Nested directories were not created"
+            )
 
-                # Verify the file was created with the correct content
-                self.assertTrue(os.path.exists(test_file_path), "File was not created")
-                with open(test_file_path) as f:
-                    file_content = f.read()
-                self.assertEqual(file_content, content)
-            else:
-                # Unexpected error
-                self.fail(f"Unexpected error: {result_text}")
+            # Verify the file was created with the correct content
+            self.assertTrue(os.path.exists(test_file_path), "File was not created")
+            with open(test_file_path) as f:
+                file_content = f.read()
+            self.assertEqual(file_content, content)
 
 
 if __name__ == "__main__":

--- a/e2e/test_edit_file.py
+++ b/e2e/test_edit_file.py
@@ -40,11 +40,17 @@ class EditFileTest(MCPEndToEndTestCase):
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for edit file test",
+                    "subject_line": "test: initialize for edit file test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -54,8 +60,9 @@ class EditFileTest(MCPEndToEndTestCase):
             )
             chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
 
-            # Call the EditFile tool with chat_id
-            result = await session.call_tool(
+            # Call the EditFile tool with chat_id using our new helper method
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "EditFile",
@@ -66,12 +73,6 @@ class EditFileTest(MCPEndToEndTestCase):
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-
-            # Extract the text content for assertions
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify the success message
             self.assertIn("Successfully edited", result_text)
@@ -135,11 +136,17 @@ nothing to commit, working tree clean
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for untracked file test",
+                    "subject_line": "test: initialize for untracked file test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -152,6 +159,7 @@ nothing to commit, working tree clean
             # Try to edit the untracked file
             new_content = "Modified untracked content"
 
+            # Using regular session.call_tool because we expect this to fail
             result = await session.call_tool(
                 "codemcp",
                 {
@@ -196,11 +204,17 @@ nothing to commit, working tree clean
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for untracked directory test",
+                    "subject_line": "test: initialize for untracked directory test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -211,7 +225,9 @@ nothing to commit, working tree clean
             chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
 
             # Try to create a new file using EditFile with empty old_string
-            result = await session.call_tool(
+            # Using call_tool_assert_success since we expect this to succeed
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "EditFile",
@@ -222,10 +238,6 @@ nothing to commit, working tree clean
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Since we've changed the behavior, we now expect this to succeed
             self.assertIn("Successfully created", result_text)
@@ -320,11 +332,17 @@ nothing to commit, working tree clean
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for git-removed file test",
+                    "subject_line": "test: initialize for git-removed file test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -335,6 +353,7 @@ nothing to commit, working tree clean
             chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
 
             # Try to write to the removed file
+            # Not using call_tool_assert_success because behavior is conditional
             result = await session.call_tool(
                 "codemcp",
                 {

--- a/e2e/test_format.py
+++ b/e2e/test_format.py
@@ -86,11 +86,17 @@ format = ["./run_format.sh"]
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for format test",
+                    "subject_line": "test: initialize for format test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -101,7 +107,8 @@ format = ["./run_format.sh"]
             chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
 
             # Call the RunCommand tool with format command and chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "RunCommand",
@@ -110,10 +117,6 @@ format = ["./run_format.sh"]
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify the success message
             self.assertIn("Code format successful", result_text)

--- a/e2e/test_git_amend_whitespace.py
+++ b/e2e/test_git_amend_whitespace.py
@@ -44,7 +44,8 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
 
         async with self.create_client_session() as session:
             # First edit with our chat_id
-            result1 = await session.call_tool(
+            result_text1 = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "EditFile",
@@ -68,7 +69,8 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
             )
 
             # Second edit with the same chat_id
-            result2 = await session.call_tool(
+            result_text2 = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "EditFile",
@@ -136,7 +138,8 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
             )
 
             # Third edit to check multiple aligned entries
-            result3 = await session.call_tool(
+            result_text3 = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "EditFile",

--- a/e2e/test_grep.py
+++ b/e2e/test_grep.py
@@ -59,7 +59,8 @@ class GrepTest(MCPEndToEndTestCase):
             chat_id = await self.get_chat_id(session)
 
             # Call the Grep tool with directory path
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "Grep",
@@ -68,10 +69,6 @@ class GrepTest(MCPEndToEndTestCase):
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize and extract result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify results
             self.assertIn("file1.js", result_text)
@@ -90,7 +87,8 @@ class GrepTest(MCPEndToEndTestCase):
             file_path = os.path.join(self.temp_dir.name, "file1.js")
 
             # Call the Grep tool with file path
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "Grep",
@@ -99,10 +97,6 @@ class GrepTest(MCPEndToEndTestCase):
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize and extract result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify results - should only find the specific file
             self.assertIn("file1.js", result_text)
@@ -116,7 +110,8 @@ class GrepTest(MCPEndToEndTestCase):
             chat_id = await self.get_chat_id(session)
 
             # Call the Grep tool with an include filter
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "Grep",
@@ -126,10 +121,6 @@ class GrepTest(MCPEndToEndTestCase):
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize and extract result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify results - should only find Python files
             self.assertIn("script.py", result_text)

--- a/e2e/test_lint.py
+++ b/e2e/test_lint.py
@@ -99,11 +99,17 @@ lint = ["./run_lint.sh"]
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for lint test",
+                    "subject_line": "test: initialize for lint test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -114,7 +120,8 @@ lint = ["./run_lint.sh"]
             chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
 
             # Call the RunCommand tool with lint command and chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "RunCommand",
@@ -123,10 +130,6 @@ lint = ["./run_lint.sh"]
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify the success message
             self.assertIn("Code lint successful", result_text)

--- a/e2e/test_ls.py
+++ b/e2e/test_ls.py
@@ -32,11 +32,17 @@ class LSTest(MCPEndToEndTestCase):
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
-            init_result = await session.call_tool(
+            init_result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
-                {"subtool": "InitProject", "path": self.temp_dir.name},
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for LS test",
+                    "subject_line": "test: initialize for LS test",
+                    "reuse_head_chat_id": False,
+                },
             )
-            init_result_text = self.extract_text_from_result(init_result)
 
             # Extract chat_id from the init result
             import re
@@ -47,14 +53,11 @@ class LSTest(MCPEndToEndTestCase):
             chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
 
             # Call the LS tool with chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {"subtool": "LS", "path": test_dir, "chat_id": chat_id},
             )
-
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify the result includes all files and directories
             self.assertIn("file1.txt", result_text)

--- a/e2e/test_read_file.py
+++ b/e2e/test_read_file.py
@@ -24,14 +24,11 @@ class ReadFileTest(MCPEndToEndTestCase):
             chat_id = await self.get_chat_id(session)
 
             # Call the ReadFile tool with the chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {"subtool": "ReadFile", "path": test_file_path, "chat_id": chat_id},
             )
-
-            # Normalize the result for easier comparison
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify the result includes our file content (ignoring line numbers)
             for line in test_content.splitlines():
@@ -50,7 +47,8 @@ class ReadFileTest(MCPEndToEndTestCase):
             chat_id = await self.get_chat_id(session)
 
             # Call the ReadFile tool with offset and limit and the chat_id
-            result = await session.call_tool(
+            result_text = await self.call_tool_assert_success(
+                session,
                 "codemcp",
                 {
                     "subtool": "ReadFile",
@@ -60,10 +58,6 @@ class ReadFileTest(MCPEndToEndTestCase):
                     "chat_id": chat_id,
                 },
             )
-
-            # Normalize the result
-            normalized_result = self.normalize_path(result)
-            result_text = self.extract_text_from_result(normalized_result)
 
             # Verify we got exactly lines 2-3
             self.assertIn("Line 2", result_text)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #45
* #44
* #43
* #42
* #41
* #40

We are continuing a test refactor:
1. We started by implementing a new helper method called `call_tool_assert_success` in the `MCPEndToEndTestCase` class that:
   * Calls a tool with provided parameters
   * Asserts that the result is not an error (isError=False)
   * Returns the normalized, extracted text result
2. We've updated several test files to use this new helper method:
   * `test_write_file.py`: Updated all tests to use the helper method for InitProject calls and for WriteFile/EditFile calls that are expected to succeed
   * `test_init_project.py`: Updated all tests to use the helper method for InitProject calls
   * `test_git_amend.py`: Updated several tests to use the helper method for EditFile and WriteFile calls that are expected to succeed
3. For each file, we've:
   * Run tests to verify the changes work correctly
   * Run formatting to ensure code meets project style guidelines
   * Updated the PR
The remaining work is to continue updating the rest of the e2e test files to use the new helper method, with the next file being `test_security.py`. This standardizes test assertions for tool calls and makes explicit the assumption that tools will succeed by default.

```git-revs
26d774f  (Base revision)
6401154  Add InitProject call using call_tool_assert_success and extract chat_id for the write_to_gitignored_file test
20bcbdf  Add InitProject call using call_tool_assert_success and extract chat_id for the path traversal test
HEAD     Fix parameter naming in EditFile call (file_path -> path)
```

codemcp-id: 105-refactor-tests-update-test-security-py-to-use-call