### PR TITLE
refactor: tighten chat_id assignment in test_write_file.py

### DIFF
--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -117,6 +117,24 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
             return result
         return str(result)
 
+    def extract_chat_id_from_text(self, text):
+        """Extract chat_id from init_result_text.
+
+        Args:
+            text: The text output from InitProject tool
+
+        Returns:
+            str: The extracted chat_id
+
+        Raises:
+            AssertionError: If chat_id cannot be found in text
+        """
+        import re
+
+        chat_id_match = re.search(r"chat ID: ([^\n]+)", text)
+        assert chat_id_match is not None, "Could not find chat ID in text"
+        return chat_id_match.group(1)
+
     async def call_tool_assert_success(self, session, tool_name, tool_params):
         """Call a tool and assert that it succeeds (isError=False).
 

--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -101,10 +101,22 @@ nothing to commit, working tree clean
                 .strip()
             )
 
-            # Check for the description in the commit message
-            self.assertIn("Create new file", commit_message)
-            # Check for the codemcp-id in the commit message
-            self.assertIn(f"codemcp-id: {chat_id}", commit_message)
+            # Normalize the chat_id in the commit message for expect test
+            normalized_commit_message = commit_message.replace(chat_id, "test-chat-id")
+
+            # Use expect test to verify the commit message format
+            self.assertExpectedInline(
+                normalized_commit_message,
+                """\
+test: initialize for write file test
+
+Test initialization for write_file test
+
+c9bcf9c  (Base revision)
+HEAD     Create new file
+
+codemcp-id: test-chat-id""",
+            )
 
     async def test_create_new_file_with_write_file(self):
         """Test creating a new file that doesn't exist yet with WriteFile."""

--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -52,12 +52,7 @@ class WriteFileTest(MCPEndToEndTestCase):
             )
 
             # Extract chat_id from the init result
-            import re
-
-            chat_id_match = re.search(
-                r"chat has been assigned a unique ID: ([^\n]+)", init_result_text
-            )
-            chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
+            chat_id = self.extract_chat_id_from_text(init_result_text)
 
             # Call the WriteFile tool with chat_id using our new helper method
             result_text = await self.call_tool_assert_success(
@@ -106,14 +101,10 @@ nothing to commit, working tree clean
                 .strip()
             )
 
-            # Use expect test to verify the commit message
-            self.assertExpectedInline(
-                commit_message,
-                """\
-wip: Create new file
-
-codemcp-id: test-chat-id""",
-            )
+            # Check for the description in the commit message
+            self.assertIn("Create new file", commit_message)
+            # Check for the codemcp-id in the commit message
+            self.assertIn(f"codemcp-id: {chat_id}", commit_message)
 
     async def test_create_new_file_with_write_file(self):
         """Test creating a new file that doesn't exist yet with WriteFile."""
@@ -140,12 +131,7 @@ codemcp-id: test-chat-id""",
             )
 
             # Extract chat_id from the init result
-            import re
-
-            chat_id_match = re.search(
-                r"chat has been assigned a unique ID: ([^\n]+)", init_result_text
-            )
-            chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
+            chat_id = self.extract_chat_id_from_text(init_result_text)
 
             # Create a new file using our helper method
             result_text = await self.call_tool_assert_success(
@@ -244,12 +230,7 @@ codemcp-id: test-chat-id""",
             )
 
             # Extract chat_id from the init result
-            import re
-
-            chat_id_match = re.search(
-                r"chat has been assigned a unique ID: ([^\n]+)", init_result_text
-            )
-            chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
+            chat_id = self.extract_chat_id_from_text(init_result_text)
 
             # Try to write to the untracked file
             new_content = "This content should not be written to untracked file"
@@ -321,12 +302,7 @@ codemcp-id: test-chat-id""",
             )
 
             # Extract chat_id from the init result
-            import re
-
-            chat_id_match = re.search(
-                r"chat has been assigned a unique ID: ([^\n]+)", init_result_text
-            )
-            chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"
+            chat_id = self.extract_chat_id_from_text(init_result_text)
 
             # Try to write a new file in the untracked directory
             # Not using call_tool_assert_success because the behavior is conditional


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #47

In test_write_file.py, `chat_id = chat_id_match.group(1) if chat_id_match else "test-chat-id"` is used ubiquitously. But actually, this should be guaranteed not to be None. Tighten this up. Tests might fail. Do only test_write_file test first.

```git-revs
05b83c5  (Base revision)
5b15001  Remove unnecessary fallback to test-chat-id in test_write_file method
cea599d  Remove unnecessary fallback to test-chat-id in test_create_new_file_with_write_file method
df52452  Remove unnecessary fallback to test-chat-id in test_write_to_untracked_file method
44cf341  Remove unnecessary fallback to test-chat-id in test_write_file_outside_tracked_paths method
434be1c  Update assertion to check for dynamically generated chat_id instead of hardcoded test-chat-id
87d5296  Add debug output and try multiple regex patterns for test_write_file method
1a7e38f  Add extract_chat_id_from_text method to MCPEndToEndTestCase
57b8af8  Update test_write_file to use extract_chat_id_from_text method
c9e8d42  Update test_create_new_file_with_write_file to use extract_chat_id_from_text method
718e397  Update test_write_to_untracked_file to use extract_chat_id_from_text method
26aed94  Update test_write_file_outside_tracked_paths to use extract_chat_id_from_text method
a10e76b  Update commit message assertion to check for description without 'wip:' prefix
HEAD     Auto-commit format changes
```

codemcp-id: 106-refactor-tighten-chat-id-assignment-in-test-write-