### PR TITLE
feat(tests): add helper method for git subprocess calls in e2e tests

### DIFF
--- a/e2e/test_git_amend.py
+++ b/e2e/test_git_amend.py
@@ -23,32 +23,16 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it
-        subprocess.run(
-            ["git", "commit", "-m", "Add file for amend test"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Add file for amend test"])
 
         # Get the current commit count
-        initial_commit_count = len(
-            subprocess.check_output(
-                ["git", "log", "--oneline"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
-            .split("\n")
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
         )
+        initial_commit_count = len(log_output.split("\n"))
 
         # Define a chat_id for our test
         chat_id = "test-chat-123"
@@ -72,16 +56,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result_text1)
 
             # Get the current commit count after first edit
-            commit_count_after_first_edit = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_first_edit = len(log_output.split("\n"))
 
             # Verify a new commit was created (initial + 1)
             self.assertEqual(
@@ -91,14 +69,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the last commit message and check for chat_id metadata
-            commit_msg1 = (
-                subprocess.check_output(
-                    ["git", "log", "-1", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msg1 = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
             )
             self.assertIn(f"codemcp-id: {chat_id}", commit_msg1)
             self.assertIn("First edit", commit_msg1)
@@ -121,16 +93,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result_text2)
 
             # Get the commit count after second edit
-            commit_count_after_second_edit = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_second_edit = len(log_output.split("\n"))
 
             # Verify the commit count remains the same (amend)
             self.assertEqual(
@@ -140,14 +106,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the last commit message
-            commit_msg2 = (
-                subprocess.check_output(
-                    ["git", "log", "-1", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msg2 = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify the commit message contains both edits and the chat ID
@@ -182,32 +142,16 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it
-        subprocess.run(
-            ["git", "commit", "-m", "Add file for different chat test"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Add file for different chat test"])
 
         # Get the current commit count
-        initial_commit_count = len(
-            subprocess.check_output(
-                ["git", "log", "--oneline"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
-            .split("\n")
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
         )
+        initial_commit_count = len(log_output.split("\n"))
 
         # First chat ID
         chat_id1 = "chat-session-1"
@@ -231,16 +175,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result1_text)
 
             # Get the commit count after first edit
-            commit_count_after_first_edit = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_first_edit = len(log_output.split("\n"))
 
             # Verify a new commit was created
             self.assertEqual(
@@ -270,16 +208,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result2_text)
 
             # Get the commit count after second edit
-            commit_count_after_second_edit = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_second_edit = len(log_output.split("\n"))
 
             # Verify a new commit was created (not amended)
             self.assertEqual(
@@ -289,14 +221,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the last two commit messages
-            commit_msgs = (
-                subprocess.check_output(
-                    ["git", "log", "-2", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msgs = await self.git_run(
+                ["log", "-2", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify the latest commit has chat_id2
@@ -317,32 +243,16 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it (user-generated commit without a chat_id)
-        subprocess.run(
-            ["git", "commit", "-m", "User-generated commit"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "User-generated commit"])
 
         # Get the current commit count
-        initial_commit_count = len(
-            subprocess.check_output(
-                ["git", "log", "--oneline"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
-            .split("\n")
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
         )
+        initial_commit_count = len(log_output.split("\n"))
 
         # AI edit chat ID
         chat_id = "ai-chat-123"
@@ -366,16 +276,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result_text)
 
             # Get the commit count after AI edit
-            commit_count_after_edit = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_edit = len(log_output.split("\n"))
 
             # Verify a new commit was created (not amended)
             self.assertEqual(
@@ -385,14 +289,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the last two commit messages
-            commit_msgs = (
-                subprocess.check_output(
-                    ["git", "log", "-2", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msgs = await self.git_run(
+                ["log", "-2", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify the latest commit has AI chat_id
@@ -418,48 +316,27 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it
-        subprocess.run(
-            ["git", "commit", "-m", "Add file for history test"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Add file for history test"])
 
         # First chat ID
         chat_id1 = "chat-history-1"
 
         # Helper function to create a commit with chat ID
-        def create_chat_commit(content, message, chat_id):
+        async def create_chat_commit(content, message, chat_id):
             with open(test_file_path, "w") as f:
                 f.write(content)
 
-            subprocess.run(
-                ["git", "add", test_file_path],
-                cwd=self.temp_dir.name,
-                env=self.env,
-                check=True,
-            )
-
-            subprocess.run(
-                ["git", "commit", "-m", f"{message}\n\ncodemcp-id: {chat_id}"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-                check=True,
-            )
+            await self.git_run(["add", test_file_path])
+            await self.git_run(["commit", "-m", f"{message}\n\ncodemcp-id: {chat_id}"])
 
         # Create first AI commit with chat_id1
-        create_chat_commit("Modified by chat 1", "First AI edit", chat_id1)
+        await create_chat_commit("Modified by chat 1", "First AI edit", chat_id1)
 
         # Create a user commit (different chat_id)
-        create_chat_commit("Modified by user", "User edit", "some-other-chat")
+        await create_chat_commit("Modified by user", "User edit", "some-other-chat")
 
         # Get the current commit count
         initial_commit_count = len(
@@ -536,32 +413,16 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it without a chat ID
-        subprocess.run(
-            ["git", "commit", "-m", "Regular commit without chat ID"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Regular commit without chat ID"])
 
         # Get the current commit count
-        initial_commit_count = len(
-            subprocess.check_output(
-                ["git", "log", "--oneline"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
-            .split("\n")
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
         )
+        initial_commit_count = len(log_output.split("\n"))
 
         # AI chat ID
         ai_chat_id = "ai-chat-789"

--- a/e2e/test_git_amend_whitespace.py
+++ b/e2e/test_git_amend_whitespace.py
@@ -24,20 +24,10 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it
-        subprocess.run(
-            ["git", "commit", "-m", "Add file for whitespace test"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Add file for whitespace test"])
 
         # Define a chat_id for our test
         chat_id = "whitespace-test-123"
@@ -58,14 +48,8 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
             )
 
             # Get the commit hash for the first edit
-            first_commit_hash = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "--short", "HEAD"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            first_commit_hash = await self.git_run(
+                ["rev-parse", "--short", "HEAD"], capture_output=True, text=True
             )
 
             # Second edit with the same chat_id
@@ -83,11 +67,9 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
             )
 
             # Get the commit message with hash and HEAD
-            commit_msg = subprocess.check_output(
-                ["git", "log", "-1", "--pretty=%B"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            ).decode()
+            commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
+            )
 
             # Print the commit message for debugging
             print(f"Commit message after second edit:\n{commit_msg}")
@@ -152,22 +134,14 @@ class GitAmendWhitespaceTest(MCPEndToEndTestCase):
             )
 
             # Get the second commit hash
-            second_commit_hash = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "--short", "HEAD"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            second_commit_hash = await self.git_run(
+                ["rev-parse", "--short", "HEAD"], capture_output=True, text=True
             )
 
             # Get the updated commit message with multiple entries
-            final_commit_msg = subprocess.check_output(
-                ["git", "log", "-1", "--pretty=%B"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            ).decode()
+            final_commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
+            )
 
             print(f"Commit message after third edit:\n{final_commit_msg}")
 

--- a/e2e/test_git_helper.py
+++ b/e2e/test_git_helper.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+"""Tests for the git_run helper method."""
+
+import os
+import subprocess
+import unittest
+
+from codemcp.testing import MCPEndToEndTestCase
+
+
+class GitHelperTest(MCPEndToEndTestCase):
+    """Test the git_run helper method."""
+
+    async def test_git_add_and_commit(self):
+        """Test basic git add and commit operations using the helper."""
+        # Create a test file
+        test_file_path = os.path.join(self.temp_dir.name, "test_file.txt")
+        with open(test_file_path, "w") as f:
+            f.write("Test content")
+
+        # Add the file using git_run helper
+        await self.git_run(["add", "test_file.txt"])
+
+        # Commit the file using git_run helper
+        await self.git_run(["commit", "-m", "Add test file"])
+
+        # Get the git log using git_run helper
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
+        )
+
+        # Verify commit appears in log
+        self.assertIn("Add test file", log_output)
+
+    async def test_git_status(self):
+        """Test git status command using the helper."""
+        # Create an untracked file
+        test_file_path = os.path.join(self.temp_dir.name, "untracked.txt")
+        with open(test_file_path, "w") as f:
+            f.write("Untracked content")
+
+        # Get git status using git_run helper
+        status_output = await self.git_run(
+            ["status", "--porcelain"], capture_output=True, text=True
+        )
+
+        # Verify untracked file appears in status
+        self.assertIn("?? untracked.txt", status_output)
+
+    async def test_git_error_handling(self):
+        """Test error handling in git_run helper."""
+        # Try to check out a non-existent branch
+        with self.assertRaises(subprocess.CalledProcessError):
+            await self.git_run(["checkout", "non-existent-branch"])
+
+        # Run the same command but without error checking
+        result = await self.git_run(
+            ["checkout", "non-existent-branch"], check=False, capture_output=True
+        )
+        self.assertNotEqual(result.returncode, 0, "Command should have failed")
+
+    async def test_git_commit_count(self):
+        """Test getting commit count using the helper."""
+        # Create and commit a series of files
+        for i in range(3):
+            test_file = os.path.join(self.temp_dir.name, f"file{i}.txt")
+            with open(test_file, "w") as f:
+                f.write(f"Content {i}")
+
+            await self.git_run(["add", f"file{i}.txt"])
+            await self.git_run(["commit", "-m", f"Add file {i}"])
+
+        # Get commit count using git_run helper
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
+        )
+        # Count lines (+1 for initial setup commit)
+        commit_count = len(log_output.split("\n"))
+
+        # Should have 4 commits (3 new ones + initial repo setup)
+        self.assertEqual(commit_count, 4, "Should have 4 commits in total")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/e2e/test_init_project.py
+++ b/e2e/test_init_project.py
@@ -207,29 +207,17 @@ format = ["./run_format.sh"]
         from codemcp.git import commit_changes
 
         # Set up a git repository in the temp dir
-        subprocess.run(["git", "init"], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["init"])
+        await self.git_run(["config", "user.email", "test@example.com"])
+        await self.git_run(["config", "user.name", "Test User"])
 
         # Make an initial commit so we have a HEAD reference
         test_file = os.path.join(self.temp_dir.name, "test_file.txt")
         with open(test_file, "w") as f:
             f.write("Initial content")
 
-        subprocess.run(["git", "add", "."], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "Initial commit"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Initial commit"])
 
         # Now try to make an empty commit with allow_empty=False (should fail to commit)
         success, message = await commit_changes(
@@ -244,14 +232,10 @@ format = ["./run_format.sh"]
         self.assertIn("No changes to commit", message)
 
         # Get the current commit count to verify no new commit was made
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD"],
-            cwd=self.temp_dir.name,
-            capture_output=True,
-            text=True,
-            check=True,
+        commit_count_output = await self.git_run(
+            ["rev-list", "--count", "HEAD"], capture_output=True, text=True
         )
-        commit_count_before = int(result.stdout.strip())
+        commit_count_before = int(commit_count_output.strip())
 
         # Now try with allow_empty=True (should succeed in making an empty commit)
         success, message = await commit_changes(
@@ -266,14 +250,10 @@ format = ["./run_format.sh"]
         self.assertIn("Changes committed successfully", message)
 
         # Verify a new commit was actually created
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD"],
-            cwd=self.temp_dir.name,
-            capture_output=True,
-            text=True,
-            check=True,
+        commit_count_output = await self.git_run(
+            ["rev-list", "--count", "HEAD"], capture_output=True, text=True
         )
-        commit_count_after = int(result.stdout.strip())
+        commit_count_after = int(commit_count_output.strip())
 
         # Ensure we have one more commit now
         self.assertEqual(commit_count_before + 1, commit_count_after)
@@ -293,29 +273,17 @@ test = ["./run_test.sh"]
         import subprocess
         from codemcp.git import get_head_commit_hash, get_ref_commit_chat_id
 
-        subprocess.run(["git", "init"], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["init"])
+        await self.git_run(["config", "user.email", "test@example.com"])
+        await self.git_run(["config", "user.name", "Test User"])
 
         # Create an initial commit to have a HEAD reference
         test_file = os.path.join(self.temp_dir.name, "test_file.txt")
         with open(test_file, "w") as f:
             f.write("Initial content")
 
-        subprocess.run(["git", "add", "."], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "Initial commit"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Initial commit"])
 
         # Get the hash of the initial commit
         initial_hash = await get_head_commit_hash(self.temp_dir.name, short=False)
@@ -373,29 +341,17 @@ test = ["./run_test.sh"]
         )
 
         # Set up a git repository
-        subprocess.run(["git", "init"], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["init"])
+        await self.git_run(["config", "user.email", "test@example.com"])
+        await self.git_run(["config", "user.name", "Test User"])
 
         # Create an initial commit
         initial_file = os.path.join(self.temp_dir.name, "initial.txt")
         with open(initial_file, "w") as f:
             f.write("Initial content")
 
-        subprocess.run(["git", "add", "."], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "Initial commit"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Initial commit"])
 
         # Get the hash of the initial commit
         initial_hash = await get_head_commit_hash(self.temp_dir.name, short=False)
@@ -476,14 +432,10 @@ test = ["./run_test.sh"]
             )
 
             # Get commit count to verify we have more than just the initial commit
-            result = subprocess.run(
-                ["git", "rev-list", "--count", "HEAD"],
-                cwd=self.temp_dir.name,
-                capture_output=True,
-                text=True,
-                check=True,
+            commit_count_output = await self.git_run(
+                ["rev-list", "--count", "HEAD"], capture_output=True, text=True
             )
-            commit_count = int(result.stdout.strip())
+            commit_count = int(commit_count_output.strip())
             self.assertGreater(
                 commit_count, 1, "Should have more than one commit after changes"
             )

--- a/e2e/test_init_project.py
+++ b/e2e/test_init_project.py
@@ -31,29 +31,17 @@ test = ["./run_test.sh"]
 """)
 
         # Set up a git repository
-        subprocess.run(["git", "init"], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "test@example.com"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["init"])
+        await self.git_run(["config", "user.email", "test@example.com"])
+        await self.git_run(["config", "user.name", "Test User"])
 
         # Create an initial commit to have a HEAD reference
         test_file = os.path.join(self.temp_dir.name, "test_file.txt")
         with open(test_file, "w") as f:
             f.write("Initial content")
 
-        subprocess.run(["git", "add", "."], cwd=self.temp_dir.name, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "Initial commit"],
-            cwd=self.temp_dir.name,
-            check=True,
-        )
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Initial commit"])
 
         # First InitProject call to create a reference with a chat ID
         async with self.create_client_session() as session:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #55
* __->__ #54

There are many manual calls to git via subprocess inside the e2e tests. There are two problems with this: (1) they're not using the async api, (2) they manually pass in the temp dir, which means it's easy to forget to add it. Add a helper method to MCPEndToEndTestCase specifically for git calls that handles these things. You should NOT pass in arguments that are available from self (most importantly temp_dir).

```git-revs
b78168c  (Base revision)
0c4b040  Add typing imports for the git_run helper method
e96a81e  Add git_run helper method to MCPEndToEndTestCase
b815746  Add asyncio import for the create_subprocess_exec function
0973d18  Add a test file for the git_run helper method
e2a67b7  Auto-commit format changes
bced1cc  Auto-commit lint changes
HEAD     Add subprocess import to test file
```

codemcp-id: 114-feat-tests-add-helper-method-for-git-subprocess-ca