### PR TITLE
refactor(testing): continue porting e2e tests to use git_run helper

### DIFF
--- a/e2e/test_format.py
+++ b/e2e/test_format.py
@@ -28,20 +28,10 @@ class RunCommandFormatTest(MCPEndToEndTestCase):
             f.write(unformatted_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", unformatted_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", unformatted_file_path])
 
         # Commit it
-        subprocess.run(
-            ["git", "commit", "-m", "Add unformatted file"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Add unformatted file"])
 
         # Create a simple format script that simulates ruff formatting
         format_script_path = os.path.join(self.temp_dir.name, "run_format.sh")
@@ -74,14 +64,8 @@ format = ["./run_format.sh"]
 """)
 
         # Record the current commit hash before formatting
-        commit_before = (
-            subprocess.check_output(
-                ["git", "rev-parse", "HEAD"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
+        commit_before = await self.git_run(
+            ["rev-parse", "HEAD"], capture_output=True, text=True
         )
 
         async with self.create_client_session() as session:
@@ -128,43 +112,27 @@ format = ["./run_format.sh"]
             self.assertEqual(file_content, expected_content)
 
             # Verify git state shows clean working tree after commit
-            status = subprocess.check_output(
-                ["git", "status"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            ).decode()
+            status = await self.git_run(["status"], capture_output=True, text=True)
 
             # Verify that the working tree is clean (changes were committed)
             self.assertExpectedInline(
                 status,
-                """On branch main
-nothing to commit, working tree clean
-""",
+                """\
+On branch main
+nothing to commit, working tree clean""",
             )
 
             # Verify that a new commit was created
-            commit_after = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "HEAD"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_after = await self.git_run(
+                ["rev-parse", "HEAD"], capture_output=True, text=True
             )
 
             # The commit hash should be different
             self.assertNotEqual(commit_before, commit_after)
 
             # Verify the commit message indicates it was a formatting change
-            commit_msg = (
-                subprocess.check_output(
-                    ["git", "log", "-1", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
             )
 
             self.assertIn("Auto-commit format changes", commit_msg)

--- a/e2e/test_git_amend.py
+++ b/e2e/test_git_amend.py
@@ -339,16 +339,10 @@ class GitAmendTest(MCPEndToEndTestCase):
         await create_chat_commit("Modified by user", "User edit", "some-other-chat")
 
         # Get the current commit count
-        initial_commit_count = len(
-            subprocess.check_output(
-                ["git", "log", "--oneline"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
-            .split("\n")
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
         )
+        initial_commit_count = len(log_output.split("\n"))
 
         async with self.create_client_session() as session:
             # New edit with the original chat_id1
@@ -369,16 +363,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result_text)
 
             # Get the commit count after the new edit
-            commit_count_after_edit = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_edit = len(log_output.split("\n"))
 
             # Verify a new commit was created (not amended) - we can't safely amend past HEAD
             self.assertEqual(
@@ -388,14 +376,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the last commit message
-            last_commit_msg = (
-                subprocess.check_output(
-                    ["git", "log", "-1", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            last_commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify the latest commit has the correct chat_id
@@ -498,33 +480,19 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Create a commit with a specific chat ID
         first_chat_id = "first-chat-123"
-        subprocess.run(
-            ["git", "commit", "-m", f"First commit\n\ncodemcp-id: {first_chat_id}"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
+        await self.git_run(
+            ["commit", "-m", f"First commit\n\ncodemcp-id: {first_chat_id}"]
         )
 
         # Get the current commit count
-        initial_commit_count = len(
-            subprocess.check_output(
-                ["git", "log", "--oneline"],
-                cwd=self.temp_dir.name,
-                env=self.env,
-            )
-            .decode()
-            .strip()
-            .split("\n")
+        log_output = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
         )
+        initial_commit_count = len(log_output.split("\n"))
 
         # Use a different chat ID for the write operation
         second_chat_id = "second-chat-456"
@@ -547,16 +515,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully wrote to", result_text)
 
             # Get the commit count after the write
-            commit_count_after_write = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_write = len(log_output.split("\n"))
 
             # Verify a new commit was created (not amended)
             self.assertEqual(
@@ -566,14 +528,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the commit messages
-            commit_msgs = (
-                subprocess.check_output(
-                    ["git", "log", "-2", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msgs = await self.git_run(
+                ["log", "-2", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify both chat IDs are in the commit history
@@ -597,20 +553,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             f.write(initial_content)
 
         # Add it to git
-        subprocess.run(
-            ["git", "add", test_file_path],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", test_file_path])
 
         # Commit it
-        subprocess.run(
-            ["git", "commit", "-m", "Add file for hash test"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["commit", "-m", "Add file for hash test"])
 
         # Define a chat_id for our test
         chat_id = "hash-test-123"
@@ -634,14 +580,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully edited", result1_text)
 
             # Get the commit hash for the first edit
-            first_commit_hash = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "--short", "HEAD"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            first_commit_hash = await self.git_run(
+                ["rev-parse", "--short", "HEAD"], capture_output=True, text=True
             )
 
             # Second edit with the same chat_id
@@ -668,14 +608,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the last commit message
-            commit_msg = (
-                subprocess.check_output(
-                    ["git", "log", "-1", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify the commit hash format in the message with base revision and HEAD
@@ -708,25 +642,13 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the second commit hash
-            second_commit_hash = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "--short", "HEAD"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            second_commit_hash = await self.git_run(
+                ["rev-parse", "--short", "HEAD"], capture_output=True, text=True
             )
 
             # Get the updated commit message
-            final_commit_msg = (
-                subprocess.check_output(
-                    ["git", "log", "-1", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            final_commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify both commit hashes appear in the correct format

--- a/e2e/test_git_amend.py
+++ b/e2e/test_git_amend.py
@@ -427,16 +427,10 @@ class GitAmendTest(MCPEndToEndTestCase):
             self.assertIn("Successfully wrote to", result_text)
 
             # Get the commit count after the write
-            commit_count_after_write = len(
-                subprocess.check_output(
-                    ["git", "log", "--oneline"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
-                .split("\n")
+            log_output = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
             )
+            commit_count_after_write = len(log_output.split("\n"))
 
             # Verify a new commit was created (not amended)
             self.assertEqual(
@@ -446,14 +440,8 @@ class GitAmendTest(MCPEndToEndTestCase):
             )
 
             # Get the commit messages
-            commit_msgs = (
-                subprocess.check_output(
-                    ["git", "log", "-2", "--pretty=%B"],
-                    cwd=self.temp_dir.name,
-                    env=self.env,
-                )
-                .decode()
-                .strip()
+            commit_msgs = await self.git_run(
+                ["log", "-2", "--pretty=%B"], capture_output=True, text=True
             )
 
             # Verify new commit has AI chat_id

--- a/e2e/test_grep.py
+++ b/e2e/test_grep.py
@@ -20,19 +20,8 @@ class GrepTest(MCPEndToEndTestCase):
         self.create_test_files()
 
         # Add our test files to git
-        subprocess.run(
-            ["git", "add", "."],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
-
-        subprocess.run(
-            ["git", "commit", "-m", "Add test files for grep"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Add test files for grep"])
 
     def create_test_files(self):
         """Create test files with content for grep testing."""

--- a/e2e/test_run_command_output_limit.py
+++ b/e2e/test_run_command_output_limit.py
@@ -43,18 +43,9 @@ verbose = ["./generate_output.sh"]
 """)
 
         # Add files to git
-        subprocess.run(
-            ["git", "add", "."],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
-
-        subprocess.run(
-            ["git", "commit", "-m", "Add test files for output truncation test"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
+        await self.git_run(["add", "."])
+        await self.git_run(
+            ["commit", "-m", "Add test files for output truncation test"]
         )
 
         async with self.create_client_session() as session:

--- a/e2e/test_run_tests.py
+++ b/e2e/test_run_tests.py
@@ -70,19 +70,8 @@ test = ["./run_test.sh"]
 """)
 
         # Add files to git
-        subprocess.run(
-            ["git", "add", "."],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
-
-        subprocess.run(
-            ["git", "commit", "-m", "Add test files"],
-            cwd=self.temp_dir.name,
-            env=self.env,
-            check=True,
-        )
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Add test files"])
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #55
* #54

We are going to continue porting to use git_run helper.

```git-revs
cd670af  (Base revision)
c3f7ad6  Replace subprocess calls with git_run helper in test_run_tests.py
5f1fe47  Replace subprocess calls with git_run helper in test_edit_file.py (1)
fadc59b  Replace subprocess calls with git_run helper in test_edit_file.py (2)
33ca6c7  Replace subprocess calls with git_run helper in test_edit_file.py (3)
af98bbb  Replace subprocess calls with git_run helper in test_edit_file.py (4)
918ddde  Replace subprocess calls with git_run helper in test_edit_file.py (5)
51bca1b  Replace subprocess calls with git_run helper in test_edit_file.py (6)
e40fd4d  Replace subprocess calls with git_run helper in test_edit_file.py (7)
729b593  Replace subprocess calls with git_run helper in test_run_command_output_limit.py
b0d4d1e  Replace subprocess calls with git_run helper in test_lint.py (1)
bc1d0b2  Replace subprocess calls with git_run helper in test_lint.py (2)
ce15096  Replace subprocess calls with git_run helper in test_lint.py (3)
4245274  Replace subprocess calls with git_run helper in test_lint.py (4)
68539a3  Replace subprocess calls with git_run helper in test_lint.py (5)
24ba6e2  Replace subprocess calls with git_run helper in test_format.py (1)
799061f  Replace subprocess calls with git_run helper in test_format.py (2)
e42739e  Replace subprocess calls with git_run helper in test_format.py (3)
dfe8179  Replace subprocess calls with git_run helper in test_format.py (4)
6ccb4e6  Replace subprocess calls with git_run helper in test_format.py (5)
aa98e94  Replace subprocess calls with git_run helper in test_grep.py
43b6d1f  Auto-commit accept changes
437e37a  Auto-commit accept changes
f5a789c  Auto-commit accept changes
HEAD     Auto-commit format changes
```

codemcp-id: 115-refactor-testing-continue-porting-e2e-tests-to-use