### PR TITLE
refactor: Simplify WriteFile commit message generation

### DIFF
--- a/codemcp/git_commit.py
+++ b/codemcp/git_commit.py
@@ -456,24 +456,13 @@ async def commit_changes(
             # Check if message already has base revision
             has_base_revision = "(Base revision)" in current_commit_message
 
-            # Prepare the commit message for amending
-            if not has_base_revision:
-                # Add base revision marker for the first edit
-                main_message = current_commit_message.replace(
-                    "\ncodemcp-id: " + chat_id, ""
-                )
-                main_message += f"\n\n{commit_hash}  (Base revision)"
-                commit_message = (
-                    main_message + f"\nHEAD     {description}\n\ncodemcp-id: {chat_id}"
-                )
-            else:
-                # Use the update function for subsequent edits
-                commit_message = update_commit_message_with_description(
-                    current_commit_message=current_commit_message,
-                    description=description,
-                    commit_hash=commit_hash,
-                    chat_id=chat_id,
-                )
+            # Always use the update function for consistent formatting
+            commit_message = update_commit_message_with_description(
+                current_commit_message=current_commit_message,
+                description=description,
+                commit_hash=commit_hash,
+                chat_id=chat_id,
+            )
 
             # Amend the previous commit
             commit_result = await run_command(

--- a/codemcp/git_message.py
+++ b/codemcp/git_message.py
@@ -71,7 +71,7 @@ def update_commit_message_with_description(
 
     This function handles the message munging logic for commit messages:
     - Updates the message by adding the description as a new entry
-    - Uses marker tokens ```git-revs and ``` to demarcate commit list
+    - Manages commit history entries in a consistent format
     - Handles base revision markers and HEAD alignment
     - Ensures the chat_id metadata is included
 
@@ -84,192 +84,82 @@ def update_commit_message_with_description(
     Returns:
         The updated commit message with the new description
     """
-    # Define marker tokens for the commit list
-    START_MARKER = "```git-revs"
-    END_MARKER = "```"
-
-    # Extract the commit message without any codemcp-id
+    # Remove any existing codemcp-id metadata
     main_message = re.sub(
         r"\ncodemcp-id:.*$", "", current_commit_message, flags=re.MULTILINE
     )
 
-    # Extract the content parts (before, between, and after markers)
-    start_marker_pos = main_message.find(START_MARKER)
-    end_marker_pos = (
-        main_message.find(END_MARKER, start_marker_pos + len(START_MARKER))
-        if start_marker_pos != -1
-        else -1
-    )
-
-    if start_marker_pos != -1 and end_marker_pos != -1:
-        # Markers exist, extract the parts
-        message_before = main_message[:start_marker_pos]
-        rev_list_content = main_message[
-            start_marker_pos + len(START_MARKER) : end_marker_pos
-        ].strip()
-        message_after = main_message[end_marker_pos + len(END_MARKER) :]
-
-        # Parse the revision list
-        rev_entries = []
-        if rev_list_content:
-            rev_entries = [
-                line.strip() for line in rev_list_content.splitlines() if line.strip()
-            ]
-
-        # Process rev_entries: replace any HEAD entries with actual commit hash
-        has_base_revision = False
-        new_rev_entries = []
-
-        for entry in rev_entries:
-            if "(Base revision)" in entry:
-                has_base_revision = True
-
-            if entry.startswith("HEAD"):
-                if commit_hash:
-                    # Replace HEAD with commit hash
-                    head_pos = entry.find("HEAD")
-                    head_len = len("HEAD")
-
-                    # Calculate the difference in length
-                    len_diff = len(commit_hash) - head_len
-
-                    # Replace HEAD with commit hash
-                    prefix = entry[:head_pos]
-                    suffix = entry[head_pos + head_len :]
-
-                    # Adjust spacing if needed
-                    if len_diff > 0 and suffix.startswith(" " * len_diff):
-                        suffix = suffix[len_diff:]
-
-                    new_entry = prefix + commit_hash + suffix
-                    new_rev_entries.append(new_entry)
+    # Extract the original subject and body (everything before the revisions)
+    # Split the message into lines to process
+    lines = main_message.splitlines()
+    
+    # Collect revision entries and non-revision content separately
+    rev_entries = []
+    message_lines = []
+    
+    # Process each line
+    in_revisions = False
+    for line in lines:
+        if "(Base revision)" in line:
+            in_revisions = True
+            rev_entries.append(line.strip())
+        elif line.strip().startswith("HEAD") and in_revisions:
+            # This is a HEAD entry in the revision section
+            if commit_hash:
+                # We're going to replace this with the actual commit hash
+                head_pos = line.find("HEAD")
+                head_len = len("HEAD")
+                
+                # Replace HEAD with commit hash
+                prefix = line[:head_pos].strip()
+                suffix = line[head_pos + head_len:].strip()
+                
+                # Add to revision entries, preserving alignment
+                rev_entries.append(f"{commit_hash}  {suffix}")
             else:
-                new_rev_entries.append(entry)
-
-        # Determine if we need to add a base revision marker
-        if not has_base_revision and commit_hash:
-            new_rev_entries.append(f"{commit_hash}  (Base revision)")
-
-        # Add new HEAD entry if we have a description
-        if description and commit_hash:
-            # Calculate padding to align with commit hash
+                rev_entries.append(line.strip())
+        elif in_revisions and line.strip() and not line.startswith("```"):
+            # Other commit hash lines in the revision section
+            rev_entries.append(line.strip())
+        elif not in_revisions:
+            # This is part of the main message
+            message_lines.append(line)
+        # Skip marker lines (```) and empty lines in the revision section
+    
+    # Clean up message lines (remove trailing empty lines)
+    while message_lines and not message_lines[-1].strip():
+        message_lines.pop()
+    
+    # Reconstruct the message part
+    message_part = "\n".join(message_lines)
+    
+    # If we don't have a base revision marker but have a commit hash, add it
+    has_base_revision = any("(Base revision)" in entry for entry in rev_entries)
+    if not has_base_revision and commit_hash:
+        rev_entries.insert(0, f"{commit_hash}  (Base revision)")
+    
+    # Add HEAD entry with the new description if provided
+    if description:
+        if commit_hash:
+            # Use alignment to match the length of commit hash for consistent layout
             head_padding = " " * (len(commit_hash) - 4)  # 4 is length of "HEAD"
-            new_rev_entries.append(f"HEAD{head_padding}  {description}")
-
-        # Reconstruct the rev list content
-        formatted_rev_list = "\n".join(new_rev_entries)
-
-        # Reconstruct the full message with markers
-        main_message = f"{message_before}{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}{message_after}"
-    else:
-        # Check for old format without markers - handle HEAD entries in the message
-        lines = main_message.splitlines()
-        has_base_revision = any("(Base revision)" in line for line in lines)
-        has_head_entry = any(line.strip().startswith("HEAD") for line in lines)
-
-        if has_head_entry or has_base_revision:
-            # Old format detected, convert to new format with markers
-            new_rev_entries = []
-            filtered_lines = []
-
-            for line in lines:
-                if "(Base revision)" in line or line.strip().startswith("HEAD"):
-                    # This is a revision entry, add to our rev entries
-                    if line.strip():
-                        if line.strip().startswith("HEAD") and commit_hash:
-                            # Replace HEAD with commit hash
-                            head_pos = line.find("HEAD")
-                            head_len = len("HEAD")
-                            len_diff = len(commit_hash) - head_len
-
-                            prefix = line[:head_pos]
-                            suffix = line[head_pos + head_len :]
-
-                            if len_diff > 0 and suffix.startswith(" " * len_diff):
-                                suffix = suffix[len_diff:]
-
-                            new_line = prefix + commit_hash + suffix
-                            new_rev_entries.append(new_line.strip())
-                        else:
-                            new_rev_entries.append(line.strip())
-                else:
-                    # Regular line, keep in message
-                    filtered_lines.append(line)
-
-            # Determine if we need to add a base revision marker
-            if not has_base_revision and commit_hash:
-                new_rev_entries.append(f"{commit_hash}  (Base revision)")
-
-            # Add new HEAD entry if we have a description
-            if description and commit_hash:
-                head_padding = " " * (len(commit_hash) - 4)
-                new_rev_entries.append(f"HEAD{head_padding}  {description}")
-
-            # Format regular message without revision entries
-            filtered_message = "\n".join(filtered_lines)
-
-            # Format revision list
-            formatted_rev_list = "\n".join(new_rev_entries)
-
-            # Create new message with markers
-            if filtered_message:
-                if filtered_message.endswith("\n\n"):
-                    main_message = f"{filtered_message}{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                elif filtered_message.endswith("\n"):
-                    main_message = f"{filtered_message}\n{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                else:
-                    main_message = f"{filtered_message}\n\n{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-            else:
-                main_message = f"{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
+            rev_entries.append(f"HEAD{head_padding}  {description}")
         else:
-            # No markers or HEAD entries, handle as normal
-            if description:
-                rev_entries = []
-
-                # If we have a commit hash, initialize with base revision
-                if commit_hash:
-                    rev_entries.append(f"{commit_hash}  (Base revision)")
-
-                    # Add HEAD entry with description
-                    head_padding = " " * (len(commit_hash) - 4)  # 4 is length of "HEAD"
-                    rev_entries.append(f"HEAD{head_padding}  {description}")
-                else:
-                    # No commit hash, just add description without revision list
-                    if main_message and not main_message.endswith("\n"):
-                        main_message += "\n"
-                    main_message += description
-
-                    # Ensure the chat ID metadata is included if provided
-                    if chat_id:
-                        return append_metadata_to_message(
-                            main_message, {"codemcp-id": chat_id}
-                        )
-                    else:
-                        return main_message
-
-                # Format the revision list with markers
-                formatted_rev_list = "\n".join(rev_entries)
-
-                # Add formatted revision list to the message
-                if main_message:
-                    # Ensure proper spacing
-                    if main_message.endswith("\n\n"):
-                        main_message += (
-                            f"{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                        )
-                    elif main_message.endswith("\n"):
-                        main_message += (
-                            f"\n{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                        )
-                    else:
-                        main_message += (
-                            f"\n\n{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-                        )
-                else:
-                    main_message = f"{START_MARKER}\n{formatted_rev_list}\n{END_MARKER}"
-
+            rev_entries.append(f"HEAD     {description}")
+    
+    # Build the final message
+    formatted_rev_list = "\n".join(rev_entries)
+    
+    if message_part:
+        if message_part.endswith("\n"):
+            final_message = f"{message_part}\n{formatted_rev_list}"
+        else:
+            final_message = f"{message_part}\n\n{formatted_rev_list}"
+    else:
+        final_message = formatted_rev_list
+    
     # Ensure the chat ID metadata is included if provided
     if chat_id:
-        return append_metadata_to_message(main_message, {"codemcp-id": chat_id})
+        return append_metadata_to_message(final_message, {"codemcp-id": chat_id})
     else:
-        return main_message
+        return final_message


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #61
* #59
* __->__ #58
* #57

test_write_file in test_write_file.py is currently failing. The test is correct but the implementation is wrong. The problem should be related to how WriteFile generates commit messages in the git helper modules. I think the code in that area is a bit messy. Rather than directly try to fix the test, can you examine the relevant functions and see if there's a refactor to make it simpler, that would also fix the test?

```git-revs
e778097  (Base revision)
0802104  Simplify commit message update logic
HEAD     Simplify commit message generation in git_commit.py
```

codemcp-id: 117-refactor-simplify-writefile-commit-message-generat