### PR TITLE
fix: ensure custom_message is always passed to create_commit_reference

### DIFF
--- a/codemcp/git_commit.py
+++ b/codemcp/git_commit.py
@@ -26,7 +26,7 @@ async def create_commit_reference(
     description: str,
     chat_id: str,
     ref_name: str = None,
-    custom_message: str = None,
+    custom_message: str = "",
 ) -> tuple[bool, str, str]:
     """Create a Git commit without advancing HEAD and store it in a reference.
 
@@ -38,13 +38,18 @@ async def create_commit_reference(
         description: Commit message describing the change
         chat_id: The unique ID of the current chat session
         ref_name: Optional custom reference name (defaults to refs/codemcp/<chat_id>)
-        custom_message: Optional custom commit message (overrides description)
+        custom_message: Custom commit message (if empty, will use description)
 
     Returns:
         A tuple of (success, message, commit_hash)
     """
     log.debug(
-        "create_commit_reference(%s, %s, %s, %s)", path, description, chat_id, ref_name
+        "create_commit_reference(%s, %s, %s, %s, %s)",
+        path,
+        description,
+        chat_id,
+        ref_name,
+        custom_message,
     )
     try:
         # First, check if this is a git repository


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #71
* #69
* #68
* #67
* #65
* __->__ #64
* #63

I would like it if custom_message argument to create_commit_reference was always passed (never None). What is blocking this?

```git-revs
6100f73  (Base revision)
7960c02  Change custom_message parameter default from None to empty string
9aef6de  Add custom_message to debug logging
HEAD     Auto-commit format changes
```

codemcp-id: 120-fix-ensure-custom-message-is-always-passed-to-crea