### PR TITLE
feat: add custom slash command support

### DIFF
--- a/codemcp/__init__.py
+++ b/codemcp/__init__.py
@@ -2,6 +2,7 @@
 
 from .main import codemcp, configure_logging, mcp, run
 from .shell import run_command
+from .slash_commands import find_slash_command, get_slash_command, load_slash_commands
 
 __all__ = [
     "configure_logging",
@@ -9,4 +10,7 @@ __all__ = [
     "mcp",
     "codemcp",
     "run_command",
+    "find_slash_command",
+    "get_slash_command",
+    "load_slash_commands",
 ]

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -54,6 +54,11 @@ async def codemcp(
     In each response after the first one, you must call the UserPrompt tool
     with the user's verbatim message text.
 
+    If a slash command is detected in the user's prompt, the UserPrompt tool will return
+    instructions which you should IMMEDIATELY follow before continuing. Custom slash commands
+    can be created by adding Markdown files to .claude/commands/ (project-specific) or
+    ~/.claude/commands/ (global) directories.
+
     Arguments:
       subtool: The subtool to run (InitProject, UserPrompt, ...)
       path: The path to the file or directory to operate on

--- a/codemcp/slash_commands.py
+++ b/codemcp/slash_commands.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+"""
+Module for handling custom slash commands in codemcp.
+
+Slash commands can be defined by users by adding Markdown files to:
+- .claude/commands/ (project-specific)
+- ~/.claude/commands/ (global)
+
+When a matching slash command is detected in the user's prompt, the contents
+of the corresponding Markdown file will be returned.
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+__all__ = [
+    "get_slash_command",
+    "find_slash_command",
+    "load_slash_commands",
+]
+
+
+def get_commands_directories() -> Tuple[Path, Path]:
+    """Get the directories where custom slash commands are stored.
+
+    Returns:
+        Tuple of (project_commands_dir, global_commands_dir)
+    """
+    # Project-specific commands directory (.claude/commands/)
+    project_commands_dir = Path(".claude/commands")
+
+    # Global commands directory (~/.claude/commands/)
+    global_commands_dir = Path.home() / ".claude/commands"
+
+    return project_commands_dir, global_commands_dir
+
+
+def load_slash_commands() -> Dict[str, str]:
+    """Load all available slash commands from the commands directories.
+
+    Returns:
+        Dict mapping command names to their content.
+    """
+    commands = {}
+    project_dir, global_dir = get_commands_directories()
+
+    # Process global commands first, so project commands can override them
+    for commands_dir in [global_dir, project_dir]:
+        if not commands_dir.exists() or not commands_dir.is_dir():
+            continue
+
+        for file_path in commands_dir.glob("*.md"):
+            command_name = (
+                file_path.stem
+            )  # Use the filename (without extension) as the command name
+
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                commands[command_name] = content
+                logging.debug(f"Loaded slash command: /{command_name}")
+            except Exception as e:
+                logging.warning(f"Error loading slash command from {file_path}: {e}")
+
+    return commands
+
+
+def find_slash_command(text: str) -> Optional[str]:
+    """Find a slash command in the given text.
+
+    Args:
+        text: The text to search for slash commands
+
+    Returns:
+        The name of the first slash command found (without the slash), or None if not found
+    """
+    # Look for patterns like /command or /command-name at the beginning of a line or after a space
+    pattern = r"(?:^|\s)\/([a-zA-Z0-9_-]+)"
+    match = re.search(pattern, text)
+
+    if match:
+        return match.group(1)
+    return None
+
+
+def get_slash_command(text: str) -> Optional[str]:
+    """Check if the text contains a slash command and return its content if found.
+
+    Args:
+        text: The text to check for slash commands
+
+    Returns:
+        The content of the matched slash command, or None if no command is found
+    """
+    command_name = find_slash_command(text)
+    if not command_name:
+        return None
+
+    commands = load_slash_commands()
+    return commands.get(command_name)

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -352,6 +352,9 @@ Remember: when making multiple file edits in a row to the same file, you should 
 Records the user's verbatim prompt text for each interaction after the initial one.
 You should call this tool with the user's exact message at the beginning of each response.
 This tool must be called in every response except for the first one where InitProject was used.
+If a slash command is detected in the user's prompt, the tool will return instructions which you 
+should IMMEDIATELY follow before continuing. Custom slash commands can be created by adding 
+Markdown files to .claude/commands/ (project-specific) or ~/.claude/commands/ (global) directories.
 
 ## LS chat_id path
 

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -2,28 +2,36 @@
 
 import logging
 
+from ..slash_commands import get_slash_command
+
 __all__ = [
     "user_prompt",
 ]
 
 
 async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
-    """Store the user's verbatim prompt text for later use.
+    """Store the user's verbatim prompt text for later use and check for slash commands.
 
-    This function currently does nothing but may be extended in the future
-    to store the prompt text for inclusion in commit messages.
+    This function checks if the user's prompt contains a slash command and returns
+    the content of the matching command file if found.
 
     Args:
         user_text: The user's original prompt verbatim
         chat_id: The unique ID of the current chat session
 
     Returns:
-        A confirmation message
+        The content of a matched slash command, or a confirmation message if no command is found
     """
     try:
         logging.info(f"Received user prompt for chat ID {chat_id}: {user_text}")
-        # For now, this is just a placeholder that returns a confirmation
-        # In the future, this might store the text for use in commit messages
+
+        # Check for slash commands
+        command_content = get_slash_command(user_text)
+        if command_content:
+            logging.info(f"Found slash command in user prompt for chat ID {chat_id}")
+            return command_content
+
+        # No slash command found, return the default confirmation
         return "User prompt received"
     except Exception as e:
         logging.warning(f"Exception suppressed in user_prompt: {e!s}", exc_info=True)

--- a/e2e/test_slash_commands.py
+++ b/e2e/test_slash_commands.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import tempfile
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from expecttest import TestCase
+
+from codemcp.tools.user_prompt import user_prompt
+
+
+class TestSlashCommands(IsolatedAsyncioTestCase, TestCase):
+    """Test the slash commands functionality."""
+
+    def setUp(self):
+        # Create temporary directories for project and global command directories
+        self.project_temp_dir = tempfile.TemporaryDirectory()
+        self.global_temp_dir = tempfile.TemporaryDirectory()
+
+        # Create the command directories
+        self.project_commands_dir = (
+            Path(self.project_temp_dir.name) / ".claude" / "commands"
+        )
+        self.global_commands_dir = (
+            Path(self.global_temp_dir.name) / ".claude" / "commands"
+        )
+
+        # Make sure the directories exist
+        self.project_commands_dir.mkdir(parents=True, exist_ok=True)
+        self.global_commands_dir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        # Clean up the temporary directories
+        self.project_temp_dir.cleanup()
+        self.global_temp_dir.cleanup()
+
+    @patch("codemcp.slash_commands.get_commands_directories")
+    async def test_slash_command_detection(self, mock_get_dirs):
+        """Test that slash commands are correctly detected and returned."""
+        # Set up the mock to return our test directories
+        mock_get_dirs.return_value = (
+            self.project_commands_dir,
+            self.global_commands_dir,
+        )
+
+        # Create a test command file in the global directory
+        test_command_path = self.global_commands_dir / "test.md"
+        test_command_content = "This is a test command instruction"
+        with open(test_command_path, "w") as f:
+            f.write(test_command_content)
+
+        # Test with a prompt containing the command
+        result = await user_prompt("Let's use the /test command", "test-chat-id")
+        self.assertExpectedInline(result, """This is a test command instruction""")
+
+        # Test with a prompt without any command
+        result = await user_prompt("This is a normal prompt", "test-chat-id")
+        self.assertExpectedInline(result, """User prompt received""")
+
+    @patch("codemcp.slash_commands.get_commands_directories")
+    async def test_project_overrides_global(self, mock_get_dirs):
+        """Test that project-specific commands override global commands."""
+        # Set up the mock to return our test directories
+        mock_get_dirs.return_value = (
+            self.project_commands_dir,
+            self.global_commands_dir,
+        )
+
+        # Create a test command file in both directories
+        global_command_path = self.global_commands_dir / "override.md"
+        project_command_path = self.project_commands_dir / "override.md"
+
+        with open(global_command_path, "w") as f:
+            f.write("Global command")
+
+        with open(project_command_path, "w") as f:
+            f.write("Project command")
+
+        # Test that the project command overrides the global one
+        result = await user_prompt("Using /override now", "test-chat-id")
+        self.assertExpectedInline(result, """Project command""")
+
+    @patch("codemcp.slash_commands.get_commands_directories")
+    async def test_command_at_beginning(self, mock_get_dirs):
+        """Test that commands at the beginning of the text are detected."""
+        # Set up the mock to return our test directories
+        mock_get_dirs.return_value = (
+            self.project_commands_dir,
+            self.global_commands_dir,
+        )
+
+        # Create a test command file
+        test_command_path = self.global_commands_dir / "begin.md"
+        with open(test_command_path, "w") as f:
+            f.write("Command at beginning")
+
+        # Test with a prompt starting with the command
+        result = await user_prompt("/begin command at the beginning", "test-chat-id")
+        self.assertExpectedInline(result, """Command at beginning""")
+
+    @patch("codemcp.slash_commands.get_commands_directories")
+    async def test_command_with_hyphen(self, mock_get_dirs):
+        """Test that commands with hyphens are properly detected."""
+        # Set up the mock to return our test directories
+        mock_get_dirs.return_value = (
+            self.project_commands_dir,
+            self.global_commands_dir,
+        )
+
+        # Create a test command file with a hyphen in the name
+        test_command_path = self.global_commands_dir / "test-command.md"
+        with open(test_command_path, "w") as f:
+            f.write("Command with hyphen")
+
+        # Test with a prompt containing the command with hyphen
+        result = await user_prompt("Let's try /test-command now", "test-chat-id")
+        self.assertExpectedInline(result, """Command with hyphen""")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #72

Let's add support for custom slash commands. You can create personalized workflows that can be invoked anytime as slash commands. Make them by adding Markdown files to your .claude/commands/ or ~/.claude/commands/ directories. The contents of those files will become new commands.

The command will be emitted when a matching slash command is seen in UserPrompt (which gets the user prompt text verbatim). Also update the tool description to indicate instructions returned from the tool should be followed.

```git-revs
eed1858  (Base revision)
f29f758  Create a new module for handling slash commands
a8cd319  Update user_prompt to detect and emit slash commands
c9f2978  Update tool description for UserPrompt to mention slash commands
a2bd8ac  Add slash_commands module to __init__.py exports
046bac2  Add end-to-end test for slash commands
04ffcd5  Update tool description to include slash commands information
e49d638  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 122-feat-add-custom-slash-command-support