### PR TITLE
refactor: make create_commit_reference raise exceptions instead of returning bool

### DIFF
--- a/codemcp/git_commit.py
+++ b/codemcp/git_commit.py
@@ -44,7 +44,7 @@ async def create_commit_reference(
         ValueError: If the chat_id format is invalid
         FileNotFoundError: If the path doesn't exist or isn't in a Git repository
         subprocess.CalledProcessError: If a Git command fails
-        RuntimeError: For other errors during the Git operations
+        Exception: For other errors during the Git operations
     """
     if not re.fullmatch(r"^[A-Za-z0-9-]+$", chat_id):
         raise ValueError(f"Invalid chat_id format: {chat_id}")
@@ -163,15 +163,10 @@ async def create_commit_reference(
         )
     except subprocess.CalledProcessError as e:
         log.warning(f"Git command failed: {e.stderr}", exc_info=True)
-        raise  # Re-raise the original exception
+        raise
     except Exception as e:
         log.warning(f"Exception when creating commit reference: {e!s}", exc_info=True)
-        # Convert generic exceptions to RuntimeError with a descriptive message
-        if not isinstance(
-            e, (ValueError, FileNotFoundError, subprocess.CalledProcessError)
-        ):
-            raise RuntimeError(f"Error creating commit reference: {e!s}") from e
-        raise  # Re-raise the original exception
+        raise
 
 
 async def commit_changes(

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -189,7 +189,7 @@ async def init_project(
             chat_id = await _generate_chat_id(full_dir_path, subject_line)
 
         # Create an empty commit with user prompt and subject line
-        from ..git import create_commit_reference
+        from ..git import GitError, create_commit_reference
 
         # We already validated that we're in a git repository
         # Format the commit message according to the specified format
@@ -198,14 +198,14 @@ async def init_project(
 
         # Create a commit reference instead of creating a regular commit
         # This will not advance HEAD but store the commit in refs/codemcp/<chat_id>
-        success, message, commit_hash = await create_commit_reference(
-            full_dir_path,
-            chat_id=chat_id,
-            commit_msg=commit_msg,
-        )
-
-        if not success:
-            logging.warning(f"Failed to create commit reference: {message}")
+        try:
+            message, commit_hash = await create_commit_reference(
+                full_dir_path,
+                chat_id=chat_id,
+                commit_msg=commit_msg,
+            )
+        except GitError as e:
+            logging.warning(f"Failed to create commit reference: {e}")
 
         project_prompt = ""
         command_help = ""

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -189,7 +189,7 @@ async def init_project(
             chat_id = await _generate_chat_id(full_dir_path, subject_line)
 
         # Create an empty commit with user prompt and subject line
-        from ..git import GitError, create_commit_reference
+        from ..git import create_commit_reference
 
         # We already validated that we're in a git repository
         # Format the commit message according to the specified format
@@ -198,14 +198,11 @@ async def init_project(
 
         # Create a commit reference instead of creating a regular commit
         # This will not advance HEAD but store the commit in refs/codemcp/<chat_id>
-        try:
-            message, commit_hash = await create_commit_reference(
-                full_dir_path,
-                chat_id=chat_id,
-                commit_msg=commit_msg,
-            )
-        except GitError as e:
-            logging.warning(f"Failed to create commit reference: {e}")
+        message, commit_hash = await create_commit_reference(
+            full_dir_path,
+            chat_id=chat_id,
+            commit_msg=commit_msg,
+        )
 
         project_prompt = ""
         command_help = ""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #76
* __->__ #75

create_commit_reference returns a bool of success or not. Refactor it to instead raise an exception on error.

```git-revs
514df6f  (Base revision)
3dd77d5  Add GitError exception class and update imports
362a05d  Update create_commit_reference to raise exceptions instead of returning a boolean
02b0110  Update init_project.py to handle the exception-raising behavior of create_commit_reference
0e97ae3  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 126-refactor-make-create-commit-reference-raise-except