### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import os
+import logging
+from typing import List, Tuple
 
 from ..common import (
     MAX_LINE_LENGTH,
@@ -8,6 +10,7 @@ from ..common import (
     MAX_OUTPUT_SIZE,
     normalize_file_path,
 )
+from ..rules import find_applicable_rules, Rule
 
 __all__ = [
     "read_file_content",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* #87
* #86
* #85
* #84
* #83
* #82
* #81
* #80
* __->__ #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
0c60751  (Base revision)
HEAD     Add imports for rules in read_file.py
```