### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/common.py
+++ b/codemcp/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+from typing import Optional
 
 # Constants
 MAX_LINES_TO_READ = 1000
@@ -18,6 +19,7 @@ __all__ = [
     "normalize_file_path",
     "get_edit_snippet",
     "truncate_output_content",
+    "find_git_root",
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* #87
* #86
* #85
* #84
* #83
* __->__ #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
5738cc2  (Base revision)
HEAD     Update imports and add find_git_root to __all__ in common.py
```