### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/common.py
+++ b/codemcp/common.py
@@ -141,3 +141,27 @@ def truncate_output_content(content: str, prefer_end: bool = True) -> str:
             truncated_content += f"\n... (output truncated, showing {MAX_LINES_TO_READ} of {total_lines} lines)"
 
     return truncated_content
+
+
+def find_git_root(start_path: str) -> Optional[str]:
+    """Find the root of the Git repository starting from the given path.
+    
+    Args:
+        start_path: The path to start searching from
+        
+    Returns:
+        The absolute path to the Git repository root, or None if not found
+    """
+    path = os.path.abspath(start_path)
+    
+    while path:
+        if os.path.isdir(os.path.join(path, ".git")):
+            return path
+        
+        parent = os.path.dirname(path)
+        if parent == path:  # Reached filesystem root
+            return None
+        
+        path = parent
+    
+    return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* #87
* #86
* #85
* #84
* __->__ #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
633d5b1  (Base revision)
HEAD     Add find_git_root helper function to common.py
```