### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -9,6 +9,7 @@ from ..common import (
     MAX_LINES_TO_READ,
     MAX_OUTPUT_SIZE,
     normalize_file_path,
+    find_git_root,
 )
 from ..rules import find_applicable_rules, Rule
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* #87
* #86
* #85
* __->__ #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
aca4158  (Base revision)
HEAD     Update read_file.py to use find_git_root
```