### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -101,13 +101,8 @@ async def read_file_content(
 
         # Apply relevant cursor rules
         try:
-            repo_root = os.path.dirname(full_file_path)
-            while repo_root and not os.path.isdir(os.path.join(repo_root, ".git")):
-                parent = os.path.dirname(repo_root)
-                if parent == repo_root:  # Reached filesystem root
-                    repo_root = None
-                    break
-                repo_root = parent
+            # Find git repository root
+            repo_root = find_git_root(os.path.dirname(full_file_path))
             
             if repo_root:
                 # Find applicable rules


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* #87
* #86
* __->__ #85
* #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
978dcab  (Base revision)
HEAD     Update read_file.py to use the find_git_root function
```