### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+from ..common import find_git_root
 from ..rules import find_applicable_rules
 
 __all__ = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* #87
* __->__ #86
* #85
* #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
1be0ada  (Base revision)
HEAD     Update imports in user_prompt.py to use find_git_root
```