### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -28,15 +28,7 @@ async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
         
         # Get the current working directory to find repo root
         cwd = os.getcwd()
-        repo_root = cwd
-        
-        # Find git repo root
-        while repo_root and not os.path.isdir(os.path.join(repo_root, ".git")):
-            parent = os.path.dirname(repo_root)
-            if parent == repo_root:  # Reached filesystem root
-                repo_root = None
-                break
-            repo_root = parent
+        repo_root = find_git_root(cwd)
         
         result = "User prompt received"
         


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* #90
* #89
* #88
* __->__ #87
* #86
* #85
* #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
085dce2  (Base revision)
HEAD     Update user_prompt.py to use the find_git_root function
```