### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/common.py
+++ b/codemcp/common.py
@@ -145,23 +145,23 @@ def truncate_output_content(content: str, prefer_end: bool = True) -> str:
 
 def find_git_root(start_path: str) -> Optional[str]:
     """Find the root of the Git repository starting from the given path.
-    
+
     Args:
         start_path: The path to start searching from
-        
+
     Returns:
         The absolute path to the Git repository root, or None if not found
     """
     path = os.path.abspath(start_path)
-    
+
     while path:
         if os.path.isdir(os.path.join(path, ".git")):
             return path
-        
+
         parent = os.path.dirname(path)
         if parent == path:  # Reached filesystem root
             return None
-        
+
         path = parent
-    
+
     return None

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -103,20 +103,22 @@ async def read_file_content(
         try:
             # Find git repository root
             repo_root = find_git_root(os.path.dirname(full_file_path))
-            
+
             if repo_root:
                 # Find applicable rules
-                applicable_rules, suggested_rules = find_applicable_rules(repo_root, full_file_path)
-                
+                applicable_rules, suggested_rules = find_applicable_rules(
+                    repo_root, full_file_path
+                )
+
                 # If we have applicable rules, add them to the output
                 if applicable_rules or suggested_rules:
                     content += "\n\n// .cursor/rules results:"
-                    
+
                     # Add directly applicable rules
                     for rule in applicable_rules:
                         rule_content = f"\n\n// Rule from {os.path.relpath(rule.file_path, repo_root)}:\n{rule.payload}"
                         content += rule_content
-                    
+
                     # Add suggestions for rules with descriptions
                     for description, rule_path in suggested_rules:
                         rel_path = os.path.relpath(rule_path, repo_root)

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -25,32 +25,32 @@ async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
     """
     try:
         logging.info(f"Received user prompt for chat ID {chat_id}: {user_text}")
-        
+
         # Get the current working directory to find repo root
         cwd = os.getcwd()
         repo_root = find_git_root(cwd)
-        
+
         result = "User prompt received"
-        
+
         # If we're in a git repo, look for applicable rules
         if repo_root:
             # Find applicable rules (no file path for UserPrompt)
             applicable_rules, suggested_rules = find_applicable_rules(repo_root)
-            
+
             # If we have applicable rules, add them to the result
             if applicable_rules or suggested_rules:
                 result += "\n\n// .cursor/rules results:"
-                
+
                 # Add directly applicable rules (alwaysApply=true)
                 for rule in applicable_rules:
                     rule_content = f"\n\n// Rule from {os.path.relpath(rule.file_path, repo_root)}:\n{rule.payload}"
                     result += rule_content
-                
+
                 # Add suggestions for rules with descriptions
                 for description, rule_path in suggested_rules:
                     rel_path = os.path.relpath(rule_path, repo_root)
                     result += f"\n\n// If {description} applies, load {rel_path}"
-        
+
         return result
     except Exception as e:
         logging.warning(f"Exception suppressed in user_prompt: {e!s}", exc_info=True)

--- a/e2e/test_cursor_rules.py
+++ b/e2e/test_cursor_rules.py
@@ -99,10 +99,10 @@ Consider time and space complexity when writing algorithms.
         # Verify that the JavaScript rule was applied
         self.assertIn("// .cursor/rules results:", result)
         self.assertIn("Use camelCase for variable names in JavaScript", result)
-        
+
         # Verify that the always-apply rule was applied
         self.assertIn("Follow PEP 8 guidelines", result)
-        
+
         # Verify that the suggested rule appears
         self.assertIn("If For code that needs optimization applies", result)
 
@@ -113,7 +113,7 @@ Consider time and space complexity when writing algorithms.
         # Verify that the Python rule was applied
         self.assertIn("// .cursor/rules results:", result)
         self.assertIn("Use snake_case for variable names in Python", result)
-        
+
         # Verify that the always-apply rule was applied
         self.assertIn("Follow PEP 8 guidelines", result)
 
@@ -124,7 +124,7 @@ Consider time and space complexity when writing algorithms.
         # Verify that the always-apply rule was applied
         self.assertIn("// .cursor/rules results:", result)
         self.assertIn("Follow PEP 8 guidelines", result)
-        
+
         # Verify that the suggested rule appears
         self.assertIn("If For code that needs optimization applies", result)
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -81,8 +81,10 @@ This is a glob test rule
         self.assertTrue(match_file_with_glob("test.js", "*.js"))
         self.assertTrue(match_file_with_glob("/path/to/test.js", "*.js"))
         self.assertTrue(match_file_with_glob("/path/to/test.js", "**/*.js"))
-        self.assertTrue(match_file_with_glob("/path/to/src/components/Button.jsx", "src/**/*.jsx"))
-        
+        self.assertTrue(
+            match_file_with_glob("/path/to/src/components/Button.jsx", "src/**/*.jsx")
+        )
+
         # Test non-matching paths
         self.assertFalse(match_file_with_glob("test.py", "*.js"))
         self.assertFalse(match_file_with_glob("/path/to/test.ts", "*.js"))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* #91
* __->__ #90
* #89
* #88
* #87
* #86
* #85
* #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
65f3c90  (Base revision)
HEAD     Auto-commit format changes
```