### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/codemcp/rules.py
+++ b/codemcp/rules.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
+import fnmatch
 import os
 import re
-import fnmatch
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 import yaml
 

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 
-import os
 import logging
-from typing import List, Tuple
+import os
 
 from ..common import (
     MAX_LINE_LENGTH,
     MAX_LINES_TO_READ,
     MAX_OUTPUT_SIZE,
-    normalize_file_path,
     find_git_root,
+    normalize_file_path,
 )
-from ..rules import find_applicable_rules, Rule
+from ..rules import find_applicable_rules
 
 __all__ = [
     "read_file_content",

--- a/e2e/test_cursor_rules.py
+++ b/e2e/test_cursor_rules.py
@@ -2,8 +2,6 @@
 
 import asyncio
 import os
-import tempfile
-from pathlib import Path
 
 from expecttest import TestCase
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
-import os
 import tempfile
 import unittest
 from pathlib import Path
 
-from codemcp.rules import Rule, load_rule_from_file, match_file_with_glob
+from codemcp.rules import load_rule_from_file, match_file_with_glob
 
 
 class TestRules(unittest.TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92
* __->__ #91
* #90
* #89
* #88
* #87
* #86
* #85
* #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
62910b0  (Base revision)
HEAD     Auto-commit lint changes
```