### PR TITLE
feat: add support for .cursor/rules

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Script to install dependencies for development
+
+# Activate virtual environment if it exists
+if [ -d ".venv" ]; then
+    source .venv/bin/activate
+fi
+
+# Install PyYAML
+pip install pyyaml
+
+echo "Dependencies installed successfully!"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92
* #91
* #90
* #89
* #88
* #87
* #86
* #85
* #84
* #83
* #82
* #81
* #80
* #79
* #78
* #77
* #76

Let's add support for .cursor/rules. These folders can live in any directory in a project and contain mdc files each of which have this format (triple hyphen, key-colon-values, triple hyphen, markdown payload):

```

```git-revs
4e4e48b  (Base revision)
HEAD     Create script to install missing dependencies
```