### PR TITLE
refactor: move find_git_root to the right file

### DIFF
--- a/codemcp/common.py
+++ b/codemcp/common.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-from typing import Optional
 
 # Constants
 MAX_LINES_TO_READ = 1000
@@ -19,7 +18,6 @@ __all__ = [
     "normalize_file_path",
     "get_edit_snippet",
     "truncate_output_content",
-    "find_git_root",
 ]
 
 
@@ -141,27 +139,3 @@ def truncate_output_content(content: str, prefer_end: bool = True) -> str:
             truncated_content += f"\n... (output truncated, showing {MAX_LINES_TO_READ} of {total_lines} lines)"
 
     return truncated_content
-
-
-def find_git_root(start_path: str) -> Optional[str]:
-    """Find the root of the Git repository starting from the given path.
-
-    Args:
-        start_path: The path to start searching from
-
-    Returns:
-        The absolute path to the Git repository root, or None if not found
-    """
-    path = os.path.abspath(start_path)
-
-    while path:
-        if os.path.isdir(os.path.join(path, ".git")):
-            return path
-
-        parent = os.path.dirname(path)
-        if parent == path:  # Reached filesystem root
-            return None
-
-        path = parent
-
-    return None

--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -14,6 +14,7 @@ __all__ = [
     "get_repository_root",
     "is_git_repository",
     "get_ref_commit_chat_id",
+    "find_git_root",
 ]
 
 log = logging.getLogger(__name__)
@@ -261,3 +262,27 @@ async def get_ref_commit_chat_id(directory: str, ref_name: str) -> str | None:
             f"Exception when getting reference commit chat ID: {e!s}", exc_info=True
         )
         return None
+
+
+def find_git_root(start_path: str) -> str | None:
+    """Find the root of the Git repository starting from the given path.
+
+    Args:
+        start_path: The path to start searching from
+
+    Returns:
+        The absolute path to the Git repository root, or None if not found
+    """
+    path = os.path.abspath(start_path)
+
+    while path:
+        if os.path.isdir(os.path.join(path, ".git")):
+            return path
+
+        parent = os.path.dirname(path)
+        if parent == path:  # Reached filesystem root
+            return None
+
+        path = parent
+
+    return None

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -7,9 +7,9 @@ from ..common import (
     MAX_LINE_LENGTH,
     MAX_LINES_TO_READ,
     MAX_OUTPUT_SIZE,
-    find_git_root,
     normalize_file_path,
 )
+from ..git_query import find_git_root
 from ..rules import find_applicable_rules
 
 __all__ = [

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from ..common import find_git_root
+from ..git_query import find_git_root
 from ..rules import find_applicable_rules
 
 __all__ = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95
* #77
* #93
* #76

find_git*root is in the wrong file, it should be in one of the git* prefix files in codemcp/; probably query.

```git-revs
8c45e42  (Base revision)
b4247d4  Add find_git_root to git_query.py __all__ list
07b80ad  Add find_git_root function to git_query.py
1fff3b1  Remove find_git_root from common.py __all__ list
b9b5698  Remove find_git_root function from common.py
0e59276  Update import in read_file.py to import find_git_root from git_query
86585e4  Update import in user_prompt.py to import find_git_root from git_query
3ea2451  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 131-refactor-move-find-git-root-to-the-right-file