### PR TITLE
refactor: Extract duplicate rule traversal logic into helper function

### DIFF
--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -10,7 +10,7 @@ from ..common import (
     normalize_file_path,
 )
 from ..git_query import find_git_root
-from ..rules import find_applicable_rules
+from ..rules import get_applicable_rules_content
 
 __all__ = [
     "read_file_content",
@@ -104,24 +104,8 @@ async def read_file_content(
             repo_root = find_git_root(os.path.dirname(full_file_path))
 
             if repo_root:
-                # Find applicable rules
-                applicable_rules, suggested_rules = find_applicable_rules(
-                    repo_root, full_file_path
-                )
-
-                # If we have applicable rules, add them to the output
-                if applicable_rules or suggested_rules:
-                    content += "\n\n// .cursor/rules results:"
-
-                    # Add directly applicable rules
-                    for rule in applicable_rules:
-                        rule_content = f"\n\n// Rule from {os.path.relpath(rule.file_path, repo_root)}:\n{rule.payload}"
-                        content += rule_content
-
-                    # Add suggestions for rules with descriptions
-                    for description, rule_path in suggested_rules:
-                        rel_path = os.path.relpath(rule_path, repo_root)
-                        content += f"\n\n// If {description} applies, load {rel_path}"
+                # Add applicable rules content
+                content += get_applicable_rules_content(repo_root, full_file_path)
         except Exception as e:
             logging.warning(f"Error applying cursor rules: {e!s}", exc_info=True)
             # Don't fail the entire file read operation if rules can't be applied

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 from ..git_query import find_git_root
-from ..rules import find_applicable_rules
+from ..rules import get_applicable_rules_content
 
 __all__ = [
     "user_prompt",
@@ -34,22 +34,8 @@ async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
 
         # If we're in a git repo, look for applicable rules
         if repo_root:
-            # Find applicable rules (no file path for UserPrompt)
-            applicable_rules, suggested_rules = find_applicable_rules(repo_root)
-
-            # If we have applicable rules, add them to the result
-            if applicable_rules or suggested_rules:
-                result += "\n\n// .cursor/rules results:"
-
-                # Add directly applicable rules (alwaysApply=true)
-                for rule in applicable_rules:
-                    rule_content = f"\n\n// Rule from {os.path.relpath(rule.file_path, repo_root)}:\n{rule.payload}"
-                    result += rule_content
-
-                # Add suggestions for rules with descriptions
-                for description, rule_path in suggested_rules:
-                    rel_path = os.path.relpath(rule_path, repo_root)
-                    result += f"\n\n// If {description} applies, load {rel_path}"
+            # Add applicable rules (no file path for UserPrompt)
+            result += get_applicable_rules_content(repo_root)
 
         return result
     except Exception as e:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96
* #77
* #93
* #76

Rule traversal in codemcp/tools/read_file.py and codemcp/tools/user_prompt.py have duplicate logic for finding rules. Refactor it into a helper function. The helper function should have an optional argument for path, and the code should be generic for when you have path and when you don't.

```git-revs
7a844d8  (Base revision)
7690b75  Add get_applicable_rules_content to __all__
88de103  Add get_applicable_rules_content helper function
b012162  Update imports to use new helper function
a7f147d  Update read_file.py to use new helper function
073b97e  Update imports in user_prompt.py
5824407  Update user_prompt.py to use new helper function
HEAD     Auto-commit format changes
```

codemcp-id: 132-refactor-extract-duplicate-rule-traversal-logic-in