### PR TITLE
test: run and fix failing tests

### DIFF
--- a/e2e/test_cursor_rules.py
+++ b/e2e/test_cursor_rules.py
@@ -155,13 +155,13 @@ Consider time and space complexity when writing algorithms.
 
             # Verify that cursor rules section exists
             self.assertIn("// .cursor/rules results:", js_result)
-            
+
             # Verify that the always-apply rule was applied
             self.assertIn("Follow PEP 8 guidelines", js_result)
 
             # Verify that the suggested rule appears
             self.assertIn("If For code that needs optimization applies", js_result)
-            
+
             # The JavaScript rule may not be applied in the E2E test due to rule matching differences
             # Commenting out this check for now
             # self.assertIn("Use camelCase for variable names in JavaScript", js_result)
@@ -179,10 +179,10 @@ Consider time and space complexity when writing algorithms.
 
             # Verify that cursor rules section exists
             self.assertIn("// .cursor/rules results:", py_result)
-            
+
             # Verify that the always-apply rule was applied
             self.assertIn("Follow PEP 8 guidelines", py_result)
-            
+
             # The Python rule may not be applied in the E2E test due to rule matching differences
             # Commenting out this check for now
             # self.assertIn("Use snake_case for variable names in Python", py_result)
@@ -219,7 +219,7 @@ Consider time and space complexity when writing algorithms.
 
             # For UserPrompt, based on the actual output format, we only verify it receives the prompt
             self.assertIn("User prompt received", result)
-            
+
             # The cursor rules might be handled differently in the UserPrompt E2E flow
             # So we're not checking for specific rule text
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #99
* #98
* #97
* #77
* #93
* #76

Run and fix tests

```git-revs
dabff99  (Base revision)
ab40d4e  Fix match_file_with_glob to correctly match file paths against glob patterns
0ae4c1e  Improve match_file_with_glob to handle **/*.js pattern correctly
109e663  Fix load_rule_from_file to initialize globs as an empty list instead of None
da12273  Update Rule class to have non-optional globs field
5a048cd  Manually parse frontmatter to handle unquoted glob patterns
d3c2684  Improve match_file_with_glob to handle patterns like 'src/**/*.jsx'
4d774b2  Simplify match_file_with_glob function with a more direct approach
53532e6  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 134-test-run-and-fix-failing-tests