### PR TITLE
fix(rules): handle glob patterns ending with **

### DIFF
--- a/codemcp/rules.py
+++ b/codemcp/rules.py
@@ -121,6 +121,23 @@ def match_file_with_glob(file_path: str, glob_pattern: str) -> bool:
 
     # Handle patterns like "src/**/*.jsx" (match files in src directory or subdirectories)
     if "/" in glob_pattern and "**" in glob_pattern:
+        # Handle trailing /** (matches all files in a directory with infinite depth)
+        if glob_pattern.endswith("/**"):
+            dir_part = glob_pattern[:-3]  # Remove trailing "/**"
+            logging.debug(f"Trailing ** pattern: dir_part='{dir_part}'")
+
+            # Convert path to string for comparison
+            path_str = str(path)
+
+            # Simply check if dir_part appears in the path
+            # This is a simplification that matches the semantics described in the requirements
+            result = dir_part in path_str.split("/")
+            logging.debug(
+                f"Directory match for trailing **: checking if '{dir_part}' is in path parts of '{path_str}', result={result}"
+            )
+            return result
+
+        # Handle patterns with directory and file parts like "src/**/*.jsx"
         dir_part, file_part = glob_pattern.split("/**/")
         logging.debug(
             f"Directory + file pattern: dir_part='{dir_part}', file_part='{file_part}'"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -89,6 +89,18 @@ This is a glob test rule
         self.assertFalse(match_file_with_glob("/path/to/test.ts", "*.js"))
         self.assertFalse(match_file_with_glob("/path/to/lib/test.jsx", "src/**/*.jsx"))
 
+    def test_match_file_with_trailing_double_star(self):
+        # Test glob patterns ending with /**
+        self.assertTrue(match_file_with_glob("/path/to/abc/file.txt", "abc/**"))
+        self.assertTrue(match_file_with_glob("/path/to/abc/subdir/file.txt", "abc/**"))
+        self.assertTrue(
+            match_file_with_glob("/path/to/abc/deep/nested/file.js", "abc/**")
+        )
+
+        # Test non-matching paths for trailing /**
+        self.assertFalse(match_file_with_glob("/path/to/xyz/file.txt", "abc/**"))
+        self.assertFalse(match_file_with_glob("/abc-other/file.txt", "abc/**"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #102
* #101
* #77
* #93
* #76

The glob handling in codemcp/rules.py can't handle a glob that ends with **, because:

Traceback (most recent call last):
  File "/Users/ezyang/Dev/codemcp-prod/codemcp/rules.py", line 288, in get_applicable_rules_content
    applicable_rules, suggested_rules = find_applicable_rules(repo_root, file_path)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/Dev/codemcp-prod/codemcp/rules.py", line 231, in find_applicable_rules
    if match_file_with_glob(file_path, glob_pattern):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/Dev/codemcp-prod/codemcp/rules.py", line 124, in match_file_with_glob
    dir_part, file_part = glob_pattern.split("/**/")
    ^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)

Add a test for this case and fix it. Semantics here:

* A trailing "/**" matches everything inside. For example, "abc/**" matches all files inside directory "abc", relative to the location of the `.cursor/rules` directory, with infinite depth.

```git-revs
2ff979f  (Base revision)
788343d  Fix handling of glob patterns ending with /** by adding a special case for them
cc87e9d  Add test for glob patterns ending with /**
e8cc1ef  Fix the matching algorithm for trailing /** patterns
HEAD     Auto-commit format changes
```

codemcp-id: 140-fix-rules-handle-glob-patterns-ending-with