### PR TITLE
refactor: change get_head_commit_message to return str only

### DIFF
--- a/codemcp.toml
+++ b/codemcp.toml
@@ -10,6 +10,15 @@ project_prompt = '''
   updated for the new argument, you should definitely make it non-optional.
 - When you make a new tool, the prompt goes in system_prompt in
   codecmp/tools/init_project.py
+- If an operation may fail, do NOT wrap it with a try-catch block to suppress
+  error and do some fallback handling.  Instead, let the exception propagate
+  to the top level so we can properly report it.  If you are trying to fix a test
+  because an exception is being thrown in this way, reason about what invariant
+  is being violated that is causing the exception to be thrown.
+- If you are trying to fix a test because an assert has failed, DO NOT remove
+  the assert. Instead, try to reason about what bug could be causing the
+  invariant to be violated. If you can't figure it out, ask the user to help
+  and halt.
 '''
 
 [commands]

--- a/codemcp/git_commit.py
+++ b/codemcp/git_commit.py
@@ -357,8 +357,6 @@ async def commit_changes(
 
         # Get the current commit message
         current_commit_message = await get_head_commit_message(git_cwd)
-        if not current_commit_message:
-            current_commit_message = ""
 
         # Verify the commit has our codemcp-id
         if chat_id and "codemcp-id: " not in current_commit_message:

--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -33,16 +33,7 @@ async def get_head_commit_message(directory: str) -> str:
         subprocess.SubprocessError: If HEAD does not exist or another git error occurs
         Exception: For any other errors during the operation
     """
-    # Check if HEAD exists
-    result = await run_command(
-        ["git", "rev-parse", "--verify", "HEAD"],
-        cwd=directory,
-        check=True,  # Will raise exception if HEAD doesn't exist
-        capture_output=True,
-        text=True,
-    )
-
-    # Get the commit message
+    # Get the commit message - this will fail if HEAD doesn't exist
     result = await run_command(
         ["git", "log", "-1", "--pretty=%B"],
         cwd=directory,

--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -20,44 +20,38 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-async def get_head_commit_message(directory: str) -> str | None:
+async def get_head_commit_message(directory: str) -> str:
     """Get the full commit message from HEAD.
 
     Args:
         directory: The directory to check
 
     Returns:
-        The commit message if available, None otherwise
+        The commit message
+
+    Raises:
+        subprocess.SubprocessError: If HEAD does not exist or another git error occurs
+        Exception: For any other errors during the operation
     """
-    try:
-        # Check if HEAD exists
-        result = await run_command(
-            ["git", "rev-parse", "--verify", "HEAD"],
-            cwd=directory,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+    # Check if HEAD exists
+    result = await run_command(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=directory,
+        check=True,  # Will raise exception if HEAD doesn't exist
+        capture_output=True,
+        text=True,
+    )
 
-        if result.returncode != 0:
-            # No commits yet
-            return None
+    # Get the commit message
+    result = await run_command(
+        ["git", "log", "-1", "--pretty=%B"],
+        cwd=directory,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
-        # Get the commit message
-        result = await run_command(
-            ["git", "log", "-1", "--pretty=%B"],
-            cwd=directory,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-
-        return result.stdout.strip()
-    except Exception as e:
-        logging.warning(
-            f"Exception when getting HEAD commit message: {e!s}", exc_info=True
-        )
-        return None
+    return result.stdout.strip()
 
 
 async def get_head_commit_hash(directory: str, short: bool = True) -> str | None:
@@ -117,8 +111,6 @@ async def get_head_commit_chat_id(directory: str) -> str | None:
     """
     try:
         commit_message = await get_head_commit_message(directory)
-        if not commit_message:
-            return None
 
         # Use regex to find the last occurrence of codemcp-id: XXX
         # The pattern looks for "codemcp-id: " followed by any characters up to a newline or end of string

--- a/e2e/test_init_project.py
+++ b/e2e/test_init_project.py
@@ -350,7 +350,6 @@ test = ["./run_test.sh"]
 
             # Verify the commit message contains the original subject and body from InitProject
             head_commit_msg = await get_head_commit_message(self.temp_dir.name)
-            self.assertIsNotNone(head_commit_msg, "Commit message should not be None")
 
             # Check that both the subject and body are in the commit message
             self.assertIn(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132
* #131
* #130
* #129
* #128
* #124
* #123
* #122
* __->__ #121

In get_head_commit_message, change the output type to be str only. We will assume HEAD exists and raise an exception otherwise. Simplify call sites so they don't have to account for None output anymore.

```git-revs
4bb4117  (Base revision)
50755b6  Update get_head_commit_message to return str only and raise exception
2425dc8  Update get_head_commit_chat_id to handle get_head_commit_message changes
c9ae07c  Update git_commit.py to handle get_head_commit_message changes
db61537  Update test file to handle get_head_commit_message changes
HEAD     Snapshot before auto-test
```

codemcp-id: 143-refactor-change-get-head-commit-message-to-return-