### PR TITLE
refactor: improve get_repository_root robustness

### DIFF
--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -104,6 +104,9 @@ async def get_head_commit_chat_id(directory: str) -> str | None:
 async def get_repository_root(path: str) -> str:
     """Get the root directory of the Git repository containing the path.
 
+    This function is robust to non-existent paths. It will walk up the directory tree
+    until it finds an existing directory, and then attempt to find the git repository root.
+
     Args:
         path: The file path to get the repository root for
 
@@ -111,27 +114,43 @@ async def get_repository_root(path: str) -> str:
         The absolute path to the repository root
 
     Raises:
+        subprocess.SubprocessError: If a git command fails
+        OSError: If there are file system related errors
         ValueError: If the path is not in a Git repository
     """
-    try:
-        # Get the directory containing the file or use the path itself if it's a directory
-        directory = os.path.dirname(path) if os.path.isfile(path) else path
+    # Get the absolute path to ensure consistency
+    abs_path = os.path.abspath(path)
 
-        # Get the absolute path to ensure consistency
-        directory = os.path.abspath(directory)
+    # Get the directory containing the file or use the path itself if it's a directory
+    directory = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
 
-        # Get the repository root
-        result = await run_command(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=directory,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+    # Handle non-existent paths by walking up the directory tree
+    # until we find an existing directory
+    original_directory = directory
+    while directory and not os.path.exists(directory):
+        logging.debug(f"Directory doesn't exist, walking up: {directory}")
+        parent = os.path.dirname(directory)
+        # If we've reached the root directory and it doesn't exist, stop
+        if parent == directory:
+            logging.debug(f"Reached root directory and it doesn't exist: {directory}")
+            raise ValueError(
+                f"No existing parent directory found for path: {original_directory}"
+            )
+        directory = parent
 
-        return result.stdout.strip()
-    except (subprocess.SubprocessError, OSError) as e:
-        raise ValueError(f"Path is not in a git repository: {str(e)}")
+    # At this point, directory exists and is the closest existing parent of the original path
+    logging.debug(f"Using existing directory for git operation: {directory}")
+
+    # Get the repository root
+    result = await run_command(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=directory,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.stdout.strip()
 
 
 async def is_git_repository(path: str) -> bool:
@@ -142,14 +161,22 @@ async def is_git_repository(path: str) -> bool:
 
     Returns:
         True if path is in a Git repository, False otherwise
-
     """
     try:
-        # Get the directory containing the file or use the path itself if it's a directory
-        directory = os.path.dirname(path) if os.path.isfile(path) else path
-
         # Get the absolute path to ensure consistency
-        directory = os.path.abspath(directory)
+        abs_path = os.path.abspath(path)
+
+        # Get the directory containing the file or use the path itself if it's a directory
+        directory = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
+
+        # Handle non-existent paths by walking up the directory tree
+        # until we find an existing directory
+        while directory and not os.path.exists(directory):
+            parent = os.path.dirname(directory)
+            # If we've reached the root directory and it doesn't exist, stop
+            if parent == directory:
+                return False
+            directory = parent
 
         # Run git command to verify this is a git repository
         await run_command(
@@ -160,21 +187,11 @@ async def is_git_repository(path: str) -> bool:
             text=True,
         )
 
-        # Also get the repository root to use for all git operations
+        # Also get the repository root to verify it's a proper git repository
         try:
-            await run_command(
-                ["git", "rev-parse", "--show-toplevel"],
-                cwd=directory,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-
-            # Store the repository root in a global or class variable if needed
-            # This could be used to ensure all git operations use the same root
-
+            await get_repository_root(directory)
             return True
-        except (subprocess.SubprocessError, OSError):
+        except (subprocess.SubprocessError, OSError, ValueError):
             # If we can't get the repo root, it's not a proper git repository
             return False
     except (subprocess.SubprocessError, OSError):

--- a/codemcp/tools/code_command.py
+++ b/codemcp/tools/code_command.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import tomli
 
 from ..common import normalize_file_path, truncate_output_content
-from ..git import commit_changes, is_git_repository
+from ..git import commit_changes, get_repository_root, is_git_repository
 from ..shell import run_command
 
 __all__ = [
@@ -65,19 +65,8 @@ async def check_for_changes(project_dir: str) -> bool:
     try:
         # Get the git repository root for reliable status checking
         try:
-            repo_root = (
-                await run_command(
-                    ["git", "rev-parse", "--show-toplevel"],
-                    cwd=project_dir,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            ).stdout.strip()
-
-            # Use the repo root as working directory for git commands
-            git_cwd = repo_root
-        except (subprocess.SubprocessError, OSError) as e:
+            git_cwd = await get_repository_root(project_dir)
+        except (subprocess.SubprocessError, OSError, ValueError) as e:
             logging.error(f"Error getting git repository root: {e}")
             # Fall back to the project directory
             git_cwd = project_dir


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132
* #131
* #130
* #129
* #128
* __->__ #124
* #123
* #122
* #121

Let's improve get_repository_root.

* First, let's robustify this implementation. The primary complication is that the path we are given may not exist, nor may its directory exist (e.g., if we're creating a/b/c, the directories a and a/b are not guaranteed to exist). This means we must walk to the innermost directory that DOES exist, and then call rev-parse.
* Next, there's no point in reraising the exception, let it propagate as is.
* I want you to audit all sites where we call git rev-parse --show-toplevel by hand. I now want these to use get_repository_root. You may need to adjust the surrounding code to stop doing directory extraction, as get_repository_root does this already.

```git-revs
04a32d4  (Base revision)
b985e85  Improve get_repository_root to handle non-existent paths and let exceptions propagate naturally
46128cc  Update is_git_repository to use get_repository_root and handle non-existent paths
204c2f8  Import get_repository_root for use in access.py
94f4275  Update get_git_base_dir to use get_repository_root
2e08317  Import get_repository_root in code_command.py
46e33cf  Update check_for_changes to use get_repository_root
d6c05b2  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 146-refactor-improve-get-repository-root-robustness