### PR TITLE
refactor: centralize codemcp-id regex patterns

### DIFF
--- a/codemcp/__init__.py
+++ b/codemcp/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from .main import codemcp, configure_logging, mcp, run
+from .regex import CHAT_ID_REGEX, CHAT_ID_VALIDATION_REGEX, COMMIT_CHAT_ID_REGEX
 from .shell import run_command
 
 __all__ = [
@@ -9,4 +10,7 @@ __all__ = [
     "mcp",
     "codemcp",
     "run_command",
+    "CHAT_ID_REGEX",
+    "CHAT_ID_VALIDATION_REGEX",
+    "COMMIT_CHAT_ID_REGEX",
 ]

--- a/codemcp/git_commit.py
+++ b/codemcp/git_commit.py
@@ -13,6 +13,7 @@ from .git_query import (
     get_head_commit_message,
     is_git_repository,
 )
+from .regex import CHAT_ID_VALIDATION_REGEX
 from .shell import run_command
 
 __all__ = ["commit_changes", "create_commit_reference"]
@@ -45,7 +46,7 @@ async def create_commit_reference(
         subprocess.CalledProcessError: If a Git command fails
         Exception: For other errors during the Git operations
     """
-    if not re.fullmatch(r"^[A-Za-z0-9-]+$", chat_id):
+    if not re.fullmatch(CHAT_ID_VALIDATION_REGEX, chat_id):
         raise ValueError(f"Invalid chat_id format: {chat_id}")
 
     log.debug(

--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 
+from .regex import COMMIT_CHAT_ID_REGEX
 from .shell import run_command
 
 __all__ = [
@@ -92,8 +93,8 @@ async def get_head_commit_chat_id(directory: str) -> str | None:
     commit_message = await get_head_commit_message(directory)
 
     # Use regex to find the last occurrence of codemcp-id: XXX
-    # The pattern looks for "codemcp-id: " followed by any characters up to a newline or end of string
-    matches = re.findall(r"codemcp-id:\s*([a-zA-Z0-9-]+)", commit_message)
+    # The pattern looks for "codemcp-id: " followed by valid chat ID characters
+    matches = re.findall(COMMIT_CHAT_ID_REGEX, commit_message)
 
     # Return the last match if any matches found
     if matches:
@@ -166,7 +167,7 @@ async def is_git_repository(path: str) -> bool:
         # Try to get the repository root - this handles path existence checks
         # and directory traversal internally
         await get_repository_root(path)
-        
+
         # If we get here, we found a valid git repository
         return True
     except (subprocess.SubprocessError, OSError, ValueError):
@@ -210,8 +211,8 @@ async def get_ref_commit_chat_id(directory: str, ref_name: str) -> str | None:
         commit_message = message_result.stdout.strip()
 
         # Use regex to find the last occurrence of codemcp-id: XXX
-        # The pattern looks for "codemcp-id: " followed by any characters up to a newline or end of string
-        matches = re.findall(r"codemcp-id:\s*([^\n]*)", commit_message)
+        # The pattern looks for "codemcp-id: " followed by valid chat ID characters
+        matches = re.findall(COMMIT_CHAT_ID_REGEX, commit_message)
 
         # Return the last match if any matches found
         if matches:

--- a/codemcp/regex.py
+++ b/codemcp/regex.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+"""Centralized regular expression patterns for codemcp."""
+
+# Regular expression for valid chat ID format (a-zA-Z0-9-)
+CHAT_ID_REGEX = r"[a-zA-Z0-9-]+"
+
+# Regular expression for validating a complete chat ID (must be all a-zA-Z0-9- characters)
+CHAT_ID_VALIDATION_REGEX = f"^{CHAT_ID_REGEX}$"
+
+# Regular expression for extracting chat ID from commit message
+COMMIT_CHAT_ID_REGEX = f"codemcp-id:\\s*({CHAT_ID_REGEX})"

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -27,7 +27,8 @@ def _slugify(text: str) -> str:
     # Convert to lowercase
     text = text.lower()
     # Replace spaces and non-alphanumeric characters with hyphens
-    text = re.sub(r"[^a-z0-9]+", "-", text)
+    # Use only characters from CHAT_ID_REGEX (which is a-zA-Z0-9- but at lowercase level it's a-z0-9-)
+    text = re.sub(r"[^a-z0-9-]+", "-", text)
     # Remove leading and trailing hyphens
     text = text.strip("-")
     # If empty after processing, return a default value


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126
* #124
* #123
* #122
* #121

In get_ref_commit_chat_id there is a regex for codemcp-id. There are several places in codebase that do similar regex. Centralize them. Prefer the regex variant that enumerates valid id a-zA-Z0-9-

```git-revs
ad20190  (Base revision)
b24b915  Create regex.py with centralized regex patterns
fd0d680  Update __init__.py to export regex patterns
0216f64  Update git_query.py to import centralized regex pattern
fa0e3fb  Update get_head_commit_chat_id to use centralized regex pattern
0c70985  Update get_ref_commit_chat_id to use centralized regex pattern
7171445  Update git_commit.py to import centralized validation regex
17895b9  Update chat_id validation in create_commit_reference
5ed58fa  Import centralized regex pattern in tools/init_project.py
01808dc  Update _slugify to use consistent character set with CHAT_ID_REGEX
f9ef779  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 148-refactor-centralize-codemcp-id-regex-patterns