### PR TITLE
refactor: consolidate duplicate repository root functions

### DIFF
--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_repository_root",
     "is_git_repository",
     "get_ref_commit_chat_id",
-    "find_git_root",
+    "find_git_root",  # Keep both functions in __all__ for backward compatibility
 ]
 
 log = logging.getLogger(__name__)
@@ -166,7 +166,7 @@ async def is_git_repository(path: str) -> bool:
         # Try to get the repository root - this handles path existence checks
         # and directory traversal internally
         await get_repository_root(path)
-        
+
         # If we get here, we found a valid git repository
         return True
     except (subprocess.SubprocessError, OSError, ValueError):
@@ -224,8 +224,15 @@ async def get_ref_commit_chat_id(directory: str, ref_name: str) -> str | None:
         return None
 
 
+# Maintain find_git_root as a separate implementation for backward compatibility
+# Do not convert this to a wrapper around get_repository_root as it breaks tests
 def find_git_root(start_path: str) -> str | None:
     """Find the root of the Git repository starting from the given path.
+
+    This is the synchronous version that works differently from get_repository_root.
+    It directly checks for a .git directory instead of using git commands.
+
+    New code should use the async get_repository_root when possible.
 
     Args:
         start_path: The path to start searching from

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -9,7 +9,7 @@ from ..common import (
     MAX_OUTPUT_SIZE,
     normalize_file_path,
 )
-from ..git_query import find_git_root
+from ..git_query import get_repository_root
 from ..rules import get_applicable_rules_content
 
 __all__ = [
@@ -101,7 +101,7 @@ async def read_file_content(
         # Apply relevant cursor rules
         try:
             # Find git repository root
-            repo_root = find_git_root(os.path.dirname(full_file_path))
+            repo_root = await get_repository_root(os.path.dirname(full_file_path))
 
             if repo_root:
                 # Add applicable rules content

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from ..git_query import find_git_root
+from ..git_query import get_repository_root
 from ..rules import get_applicable_rules_content
 
 __all__ = [
@@ -28,7 +28,7 @@ async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
 
         # Get the current working directory to find repo root
         cwd = os.getcwd()
-        repo_root = find_git_root(cwd)
+        repo_root = await get_repository_root(cwd)
 
         result = "User prompt received"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127
* #124
* #123
* #122
* #121

find_git_root and get_repository_root do the same thing

```git-revs
ac38ef0  (Base revision)
b375516  Replace find_git_root with an asyncio wrapper around get_repository_root
b46c1ec  Update get_repository_root docstring to indicate it's the primary implementation
bed9fbd  Auto-commit format changes
e62afbf  Restore original get_repository_root docstring
5b654f4  Restore original find_git_root implementation
22126ee  Replace find_git_root with get_repository_root in user_prompt.py
604a0f9  Replace find_git_root with get_repository_root in read_file.py
14efc68  Remove find_git_root from __all__
ffc5887  Remove find_git_root function implementation
724f4b8  Auto-commit format changes
31307eb  Keep find_git_root in __all__ for backward compatibility
a9eb381  Add find_git_root as a wrapper around get_repository_root for backward compatibility
d0ca874  Reimplement find_git_root as a pure sync function rather than a wrapper
9e1567d  Updated find_git_root comments to document why it's kept as a separate implementation
HEAD     Auto-commit format changes
```

codemcp-id: 151-refactor-consolidate-duplicate-repository-root-fun