### PR TITLE
refactor: let exceptions propagate up in tools instead of suppressing them

### DIFF
--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -166,7 +166,7 @@ async def is_git_repository(path: str) -> bool:
         # Try to get the repository root - this handles path existence checks
         # and directory traversal internally
         await get_repository_root(path)
-        
+
         # If we get here, we found a valid git repository
         return True
     except (subprocess.SubprocessError, OSError, ValueError):

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -177,47 +177,30 @@ async def glob_files(
     if path is None:
         path = os.getcwd()
 
-    try:
-        # Set up options for glob
-        options = {
-            "limit": limit,
-            "offset": offset,
-        }
+    # Set up options for glob
+    options = {
+        "limit": limit,
+        "offset": offset,
+    }
 
-        # Execute glob
-        result = await glob(pattern, path, options, signal)
+    # Execute glob
+    result = await glob(pattern, path, options, signal)
 
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000
-        )  # Convert to milliseconds
+    # Calculate execution time
+    execution_time = int((time.time() - start_time) * 1000)  # Convert to milliseconds
 
-        # Get matching files
-        files = result.get("files", [])
+    # Get matching files
+    files = result.get("files", [])
 
-        # Prepare output
-        output = {
-            "filenames": files,
-            "durationMs": execution_time,
-            "numFiles": len(files),
-            "truncated": result.get("truncated", False),
-        }
+    # Prepare output
+    output = {
+        "filenames": files,
+        "durationMs": execution_time,
+        "numFiles": len(files),
+        "truncated": result.get("truncated", False),
+    }
 
-        # Add formatted result for assistant
-        output["resultForAssistant"] = render_result_for_assistant(output)
+    # Add formatted result for assistant
+    output["resultForAssistant"] = render_result_for_assistant(output)
 
-        return output
-    except Exception as e:
-        # Calculate execution time even on error
-        execution_time = int((time.time() - start_time) * 1000)
-
-        # Return empty results with error info
-        error_output = {
-            "filenames": [],
-            "durationMs": execution_time,
-            "numFiles": 0,
-            "error": str(e),
-            "resultForAssistant": f"Error: {e!s}",
-        }
-
-        return error_output
+    return output

--- a/codemcp/tools/grep.py
+++ b/codemcp/tools/grep.py
@@ -178,71 +178,56 @@ async def grep_files(
     """
     start_time = time.time()
 
+    # Execute git grep asynchronously
+    matches = await git_grep(pattern, path, include, signal)
+
+    # Sort matches
     try:
-        # Execute git grep asynchronously
-        matches = await git_grep(pattern, path, include, signal)
+        # First try sorting by modification time
+        import asyncio
 
-        # Sort matches
-        try:
-            # First try sorting by modification time
-            import asyncio
+        loop = asyncio.get_event_loop()
 
-            loop = asyncio.get_event_loop()
-
-            # Get file stats asynchronously
-            stats = []
-            for match in matches:
-                stat = await loop.run_in_executor(
-                    None, lambda m=match: os.stat(m) if os.path.exists(m) else None
-                )
-                stats.append(stat)
-
-            matches_with_stats = list(zip(matches, stats, strict=False))
-
-            # In tests, sort by filename for deterministic results
-            if os.environ.get("NODE_ENV") == "test":
-                matches_with_stats.sort(key=lambda x: x[0])
-            else:
-                # Sort by modification time (newest first), with filename as tiebreaker
-                matches_with_stats.sort(
-                    key=lambda x: (-(x[1].st_mtime if x[1] else 0), x[0])
-                )
-
-            matches = [match for match, _ in matches_with_stats]
-        except Exception as e:
-            # Fall back to sorting by name if there's an error
-            logging.debug(
-                f"Error sorting by modification time, falling back to name sort: {e!s}",
+        # Get file stats asynchronously
+        stats = []
+        for match in matches:
+            stat = await loop.run_in_executor(
+                None, lambda m=match: os.stat(m) if os.path.exists(m) else None
             )
-            matches.sort()
+            stats.append(stat)
 
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000,
-        )  # Convert to milliseconds
+        matches_with_stats = list(zip(matches, stats, strict=False))
 
-        # Prepare output
-        output = {
-            "filenames": matches[:MAX_RESULTS],
-            "durationMs": execution_time,
-            "numFiles": len(matches),
-        }
+        # In tests, sort by filename for deterministic results
+        if os.environ.get("NODE_ENV") == "test":
+            matches_with_stats.sort(key=lambda x: x[0])
+        else:
+            # Sort by modification time (newest first), with filename as tiebreaker
+            matches_with_stats.sort(
+                key=lambda x: (-(x[1].st_mtime if x[1] else 0), x[0])
+            )
 
-        # Add formatted result for assistant
-        output["resultForAssistant"] = render_result_for_assistant(output)
-
-        return output
+        matches = [match for match, _ in matches_with_stats]
     except Exception as e:
-        # Calculate execution time even on error
-        execution_time = int((time.time() - start_time) * 1000)
+        # Fall back to sorting by name if there's an error
+        logging.debug(
+            f"Error sorting by modification time, falling back to name sort: {e!s}",
+        )
+        matches.sort()
 
-        # Return empty results with error info
-        error_output = {
-            "filenames": [],
-            "durationMs": execution_time,
-            "numFiles": 0,
-            "error": str(e),
-            "resultForAssistant": f"Error: {e!s}",
-        }
+    # Calculate execution time
+    execution_time = int(
+        (time.time() - start_time) * 1000,
+    )  # Convert to milliseconds
 
-        return error_output
+    # Prepare output
+    output = {
+        "filenames": matches[:MAX_RESULTS],
+        "durationMs": execution_time,
+        "numFiles": len(matches),
+    }
+
+    # Add formatted result for assistant
+    output["resultForAssistant"] = render_result_for_assistant(output)
+
+    return output

--- a/codemcp/tools/ls.py
+++ b/codemcp/tools/ls.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import asyncio
-import logging
 import os
 
 from ..access import check_edit_permission
@@ -30,50 +29,42 @@ async def ls_directory(directory_path: str, chat_id: str | None = None) -> str:
         chat_id: The unique ID of the current chat session
 
     Returns:
-        A formatted string representation of the directory contents, or an error message
+        A formatted string representation of the directory contents
 
     """
-    try:
-        # Normalize the directory path
-        full_directory_path = normalize_file_path(directory_path)
+    # Normalize the directory path
+    full_directory_path = normalize_file_path(directory_path)
 
-        # Validate the directory path
-        if not os.path.exists(full_directory_path):
-            raise FileNotFoundError(f"Directory does not exist: {directory_path}")
+    # Validate the directory path
+    if not os.path.exists(full_directory_path):
+        raise FileNotFoundError(f"Directory does not exist: {directory_path}")
 
-        if not os.path.isdir(full_directory_path):
-            raise NotADirectoryError(f"Path is not a directory: {directory_path}")
+    if not os.path.isdir(full_directory_path):
+        raise NotADirectoryError(f"Path is not a directory: {directory_path}")
 
-        # Safety check: Verify the directory is within a git repository with codemcp.toml
-        if not await is_git_repository(full_directory_path):
-            raise ValueError(f"Directory is not in a Git repository: {directory_path}")
+    # Safety check: Verify the directory is within a git repository with codemcp.toml
+    if not await is_git_repository(full_directory_path):
+        raise ValueError(f"Directory is not in a Git repository: {directory_path}")
 
-        # Check edit permission (which verifies codemcp.toml exists)
-        is_permitted, permission_message = await check_edit_permission(
-            full_directory_path
-        )
-        if not is_permitted:
-            raise ValueError(permission_message)
+    # Check edit permission (which verifies codemcp.toml exists)
+    is_permitted, permission_message = await check_edit_permission(full_directory_path)
+    if not is_permitted:
+        raise ValueError(permission_message)
 
-        # Get the directory contents asynchronously
-        results = await list_directory(full_directory_path)
+    # Get the directory contents asynchronously
+    results = await list_directory(full_directory_path)
 
-        # Sort the results
-        results.sort()
+    # Sort the results
+    results.sort()
 
-        # Create a file tree and print it
-        tree = create_file_tree(results)
-        tree_output = print_tree(tree, cwd=full_directory_path)
+    # Create a file tree and print it
+    tree = create_file_tree(results)
+    tree_output = print_tree(tree, cwd=full_directory_path)
 
-        # Return the result with truncation message if needed
-        if len(results) < MAX_FILES:
-            return tree_output
-        return f"{TRUNCATED_MESSAGE}{tree_output}"
-    except Exception as e:
-        logging.warning(
-            f"Exception suppressed during directory listing: {e!s}", exc_info=True
-        )
-        return f"Error listing directory: {e!s}"
+    # Return the result with truncation message if needed
+    if len(results) < MAX_FILES:
+        return tree_output
+    return f"{TRUNCATED_MESSAGE}{tree_output}"
 
 
 async def list_directory(initial_path: str) -> list[str]:

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 import os
 
 from ..common import (
@@ -32,84 +31,77 @@ async def read_file_content(
         chat_id: The unique ID of the current chat session
 
     Returns:
-        The file content as a string, or an error message
+        The file content as a string
 
     """
-    try:
-        # Normalize the file path
-        full_file_path = normalize_file_path(file_path)
+    # Normalize the file path
+    full_file_path = normalize_file_path(file_path)
 
-        # Validate the file path
-        if not os.path.exists(full_file_path):
-            # Try to find a similar file (stub - would need implementation)
-            raise FileNotFoundError(f"File does not exist: {file_path}")
+    # Validate the file path
+    if not os.path.exists(full_file_path):
+        # Try to find a similar file (stub - would need implementation)
+        raise FileNotFoundError(f"File does not exist: {file_path}")
 
-        if os.path.isdir(full_file_path):
-            raise IsADirectoryError(f"Path is a directory, not a file: {file_path}")
+    if os.path.isdir(full_file_path):
+        raise IsADirectoryError(f"Path is a directory, not a file: {file_path}")
 
-        # Check file size before reading
-        file_size = os.path.getsize(full_file_path)
-        if file_size > MAX_OUTPUT_SIZE and not offset and not limit:
-            raise ValueError(
-                f"File content ({file_size // 1024}KB) exceeds maximum allowed size ({MAX_OUTPUT_SIZE // 1024}KB). Please use offset and limit parameters to read specific portions of the file."
-            )
-
-        # Handle text files - use async file operations with anyio
-        from .async_file_utils import async_readlines
-
-        all_lines = await async_readlines(
-            full_file_path, encoding="utf-8", errors="replace"
+    # Check file size before reading
+    file_size = os.path.getsize(full_file_path)
+    if file_size > MAX_OUTPUT_SIZE and not offset and not limit:
+        raise ValueError(
+            f"File content ({file_size // 1024}KB) exceeds maximum allowed size ({MAX_OUTPUT_SIZE // 1024}KB). Please use offset and limit parameters to read specific portions of the file."
         )
 
-        # Get total line count
-        total_lines = len(all_lines)
+    # Handle text files - use async file operations with anyio
+    from .async_file_utils import async_readlines
 
-        # Handle offset (convert from 1-indexed to 0-indexed)
-        line_offset = 0 if offset is None else (offset - 1 if offset > 0 else 0)
+    all_lines = await async_readlines(
+        full_file_path, encoding="utf-8", errors="replace"
+    )
 
-        # Apply offset and limit
-        if line_offset >= total_lines:
-            raise IndexError(
-                f"Offset {offset} is beyond the end of the file (total lines: {total_lines})"
+    # Get total line count
+    total_lines = len(all_lines)
+
+    # Handle offset (convert from 1-indexed to 0-indexed)
+    line_offset = 0 if offset is None else (offset - 1 if offset > 0 else 0)
+
+    # Apply offset and limit
+    if line_offset >= total_lines:
+        raise IndexError(
+            f"Offset {offset} is beyond the end of the file (total lines: {total_lines})"
+        )
+
+    max_lines = MAX_LINES_TO_READ if limit is None else limit
+    selected_lines = all_lines[line_offset : line_offset + max_lines]
+
+    # Process lines (truncate long lines)
+    processed_lines = []
+    for line in selected_lines:
+        if len(line) > MAX_LINE_LENGTH:
+            processed_lines.append(
+                line[:MAX_LINE_LENGTH] + "... (line truncated)",
             )
+        else:
+            processed_lines.append(line)
 
-        max_lines = MAX_LINES_TO_READ if limit is None else limit
-        selected_lines = all_lines[line_offset : line_offset + max_lines]
+    # Add line numbers (1-indexed)
+    numbered_lines = []
+    for i, line in enumerate(processed_lines):
+        line_num = line_offset + i + 1  # 1-indexed line number
+        numbered_lines.append(f"{line_num:6}\t{line.rstrip()}")
 
-        # Process lines (truncate long lines)
-        processed_lines = []
-        for line in selected_lines:
-            if len(line) > MAX_LINE_LENGTH:
-                processed_lines.append(
-                    line[:MAX_LINE_LENGTH] + "... (line truncated)",
-                )
-            else:
-                processed_lines.append(line)
+    content = "\n".join(numbered_lines)
 
-        # Add line numbers (1-indexed)
-        numbered_lines = []
-        for i, line in enumerate(processed_lines):
-            line_num = line_offset + i + 1  # 1-indexed line number
-            numbered_lines.append(f"{line_num:6}\t{line.rstrip()}")
+    # Add a message if we truncated the file
+    if line_offset + len(processed_lines) < total_lines:
+        content += f"\n... (file truncated, showing {len(processed_lines)} of {total_lines} lines)"
 
-        content = "\n".join(numbered_lines)
+    # Apply relevant cursor rules
+    # Find git repository root
+    repo_root = find_git_root(os.path.dirname(full_file_path))
 
-        # Add a message if we truncated the file
-        if line_offset + len(processed_lines) < total_lines:
-            content += f"\n... (file truncated, showing {len(processed_lines)} of {total_lines} lines)"
+    if repo_root:
+        # Add applicable rules content
+        content += get_applicable_rules_content(repo_root, full_file_path)
 
-        # Apply relevant cursor rules
-        try:
-            # Find git repository root
-            repo_root = find_git_root(os.path.dirname(full_file_path))
-
-            if repo_root:
-                # Add applicable rules content
-                content += get_applicable_rules_content(repo_root, full_file_path)
-        except Exception as e:
-            logging.warning(f"Error applying cursor rules: {e!s}", exc_info=True)
-            # Don't fail the entire file read operation if rules can't be applied
-
-        return content
-    except Exception as e:
-        return f"Error reading file: {e!s}"
+    return content

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -23,21 +23,17 @@ async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
     Returns:
         A message with any applicable cursor rules
     """
-    try:
-        logging.info(f"Received user prompt for chat ID {chat_id}: {user_text}")
+    logging.info(f"Received user prompt for chat ID {chat_id}: {user_text}")
 
-        # Get the current working directory to find repo root
-        cwd = os.getcwd()
-        repo_root = find_git_root(cwd)
+    # Get the current working directory to find repo root
+    cwd = os.getcwd()
+    repo_root = find_git_root(cwd)
 
-        result = "User prompt received"
+    result = "User prompt received"
 
-        # If we're in a git repo, look for applicable rules
-        if repo_root:
-            # Add applicable rules (no file path for UserPrompt)
-            result += get_applicable_rules_content(repo_root)
+    # If we're in a git repo, look for applicable rules
+    if repo_root:
+        # Add applicable rules (no file path for UserPrompt)
+        result += get_applicable_rules_content(repo_root)
 
-        return result
-    except Exception as e:
-        logging.warning(f"Exception suppressed in user_prompt: {e!s}", exc_info=True)
-        return f"Error processing user prompt: {e!s}"
+    return result

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -95,7 +95,7 @@ async def write_file_content(
         chat_id: The unique ID of the current chat session
 
     Returns:
-        A success message or an error message
+        A success message
 
     Note:
         This function allows creating new files that don't exist yet.
@@ -103,42 +103,39 @@ async def write_file_content(
         Files must be tracked in the git repository before they can be modified.
 
     """
-    try:
-        # Validate file path and permissions
-        is_valid, error_message = await check_file_path_and_permissions(file_path)
-        if not is_valid:
-            raise ValueError(error_message)
+    # Validate file path and permissions
+    is_valid, error_message = await check_file_path_and_permissions(file_path)
+    if not is_valid:
+        raise ValueError(error_message)
 
-        # Check git tracking for existing files
-        is_tracked, track_error = await check_git_tracking_for_existing_file(
-            file_path, chat_id
-        )
-        if not is_tracked:
-            raise ValueError(track_error)
+    # Check git tracking for existing files
+    is_tracked, track_error = await check_git_tracking_for_existing_file(
+        file_path, chat_id
+    )
+    if not is_tracked:
+        raise ValueError(track_error)
 
-        # Determine encoding and line endings
-        old_file_exists = os.path.exists(file_path)
-        encoding = await detect_file_encoding(file_path) if old_file_exists else "utf-8"
+    # Determine encoding and line endings
+    old_file_exists = os.path.exists(file_path)
+    encoding = await detect_file_encoding(file_path) if old_file_exists else "utf-8"
 
-        if old_file_exists:
-            line_endings = await detect_line_endings(file_path)
-        else:
-            line_endings = detect_repo_line_endings(os.path.dirname(file_path))
-            # Ensure directory exists for new files
-            directory = os.path.dirname(file_path)
-            os.makedirs(directory, exist_ok=True)
+    if old_file_exists:
+        line_endings = await detect_line_endings(file_path)
+    else:
+        line_endings = detect_repo_line_endings(os.path.dirname(file_path))
+        # Ensure directory exists for new files
+        directory = os.path.dirname(file_path)
+        os.makedirs(directory, exist_ok=True)
 
-        # Write the content with proper encoding and line endings
-        await write_text_content(file_path, content, encoding, line_endings)
+    # Write the content with proper encoding and line endings
+    await write_text_content(file_path, content, encoding, line_endings)
 
-        # Commit the changes
-        git_message = ""
-        success, message = await commit_changes(file_path, description, chat_id)
-        if success:
-            git_message = f"\nChanges committed to git: {description}"
-        else:
-            git_message = f"\nFailed to commit changes to git: {message}"
+    # Commit the changes
+    git_message = ""
+    success, message = await commit_changes(file_path, description, chat_id)
+    if success:
+        git_message = f"\nChanges committed to git: {description}"
+    else:
+        git_message = f"\nFailed to commit changes to git: {message}"
 
-        return f"Successfully wrote to {file_path}{git_message}"
-    except Exception:
-        raise
+    return f"Successfully wrote to {file_path}{git_message}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132
* #131
* #130
* #129
* __->__ #128
* #124
* #123
* #122
* #121

In codemcp/tools there are many files where we catch all exceptions and suppress them. Instead, tools should let exceptions propagate up.

```git-revs
1208199  (Base revision)
eb863a3  Remove exception suppression in user_prompt
8c6751c  Remove exception suppression in read_file_content
0c6f1af  Remove exception suppression in ls_directory
a7f80f6  Remove exception suppression in grep_files
9c276f8  Remove exception suppression in glob_files
c61aa4f  Remove exception suppression in edit_file_content
d5afb3f  Remove unnecessary try/except block in write_file_content
93751bd  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 152-refactor-let-exceptions-propagate-up-in-tools-inst