### PR TITLE
fix: remove redundant try-except in commit_changes function

### DIFF
--- a/codemcp/git_commit.py
+++ b/codemcp/git_commit.py
@@ -182,209 +182,204 @@ async def commit_changes(
         chat_id,
         commit_all,
     )
-    try:
-        # First, check if this is a git repository
-        if not await is_git_repository(path):
-            return False, f"Path '{path}' is not in a Git repository"
+    # First, check if this is a git repository
+    if not await is_git_repository(path):
+        return False, f"Path '{path}' is not in a Git repository"
 
-        # Get absolute paths for consistency
-        abs_path = os.path.abspath(path)
+    # Get absolute paths for consistency
+    abs_path = os.path.abspath(path)
 
-        # Get the directory - if path is a file, use its directory, otherwise use the path itself
-        directory = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
+    # Get the directory - if path is a file, use its directory, otherwise use the path itself
+    directory = os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path
 
-        # If it's a file, check if it exists (only if not commit_all mode)
-        if not commit_all and os.path.isfile(abs_path) and not os.path.exists(abs_path):
-            return False, f"File does not exist: {abs_path}"
+    # If it's a file, check if it exists (only if not commit_all mode)
+    if not commit_all and os.path.isfile(abs_path) and not os.path.exists(abs_path):
+        return False, f"File does not exist: {abs_path}"
 
-        # Get the git repository root for more reliable operations
-        from .git_query import get_repository_root
+    # Get the git repository root for more reliable operations
+    from .git_query import get_repository_root
 
-        git_cwd = await get_repository_root(directory)
+    git_cwd = await get_repository_root(directory)
 
-        # Handle commit_all mode
-        if commit_all:
-            # Check if working directory has uncommitted changes
-            status_result = await run_command(
-                ["git", "status", "--porcelain"],
+    # Handle commit_all mode
+    if commit_all:
+        # Check if working directory has uncommitted changes
+        status_result = await run_command(
+            ["git", "status", "--porcelain"],
+            cwd=git_cwd,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+
+        if status_result.stdout:
+            # Add all changes to staging
+            add_result = await run_command(
+                ["git", "add", "."],
                 cwd=git_cwd,
-                capture_output=True,
                 check=True,
-                text=True,
-            )
-
-            if status_result.stdout:
-                # Add all changes to staging
-                add_result = await run_command(
-                    ["git", "add", "."],
-                    cwd=git_cwd,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            else:
-                # No changes to commit
-                return True, "No changes to commit"
-        else:
-            # Standard path-specific mode
-            # Add the path to git - could be a file or directory
-            try:
-                # If path is a directory, do git add .
-                add_command = ["git", "add", abs_path]
-
-                add_result = await run_command(
-                    add_command,
-                    cwd=git_cwd,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-            except Exception as e:
-                return False, f"Failed to add to Git: {str(e)}"
-
-            if add_result.returncode != 0:
-                return False, f"Failed to add to Git: {add_result.stderr}"
-
-        # Check if there are any changes to commit after git add
-        diff_result = await run_command(
-            ["git", "diff-index", "--cached", "--quiet", "HEAD"],
-            cwd=git_cwd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        # If diff-index returns 0, there are no changes to commit
-        if diff_result.returncode == 0:
-            return (
-                True,
-                "No changes to commit (changes already committed or no changes detected)",
-            )
-
-        # Determine whether to amend or create a new commit
-        head_chat_id = await get_head_commit_chat_id(git_cwd)
-        logging.debug(
-            "commit_changes: head_chat_id = %s",
-            head_chat_id,
-        )
-
-        verb = "amended"
-
-        # If HEAD exists but doesn't have the right chat_id, check if we have a
-        # commit reference for this chat_id that we need to cherry-pick first
-        if head_chat_id != chat_id:
-            verb = "committed"
-            ref_name = f"refs/codemcp/{chat_id}"
-            ref_exists = False
-
-            # Check if the reference exists
-            ref_result = await run_command(
-                ["git", "show-ref", "--verify", ref_name],
-                cwd=git_cwd,
-                check=False,
                 capture_output=True,
                 text=True,
             )
-            ref_exists = ref_result.returncode == 0
+        else:
+            # No changes to commit
+            return True, "No changes to commit"
+    else:
+        # Standard path-specific mode
+        # Add the path to git - could be a file or directory
+        try:
+            # If path is a directory, do git add .
+            add_command = ["git", "add", abs_path]
 
-            if ref_exists:
-                # Using git plumbing commands instead of cherry-pick to avoid conflicts with local changes
-                logging.info(f"Creating a new commit from reference {ref_name}")
+            add_result = await run_command(
+                add_command,
+                cwd=git_cwd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except Exception as e:
+            return False, f"Failed to add to Git: {str(e)}"
 
-                # Get the current HEAD commit hash
-                head_hash = await get_head_commit_hash(git_cwd, short=False)
+        if add_result.returncode != 0:
+            return False, f"Failed to add to Git: {add_result.stderr}"
 
-                # Get the tree from HEAD
-                tree_result = await run_command(
-                    ["git", "show", "-s", "--format=%T", "HEAD"],
-                    cwd=git_cwd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                tree_hash = tree_result.stdout.strip()
+    # Check if there are any changes to commit after git add
+    diff_result = await run_command(
+        ["git", "diff-index", "--cached", "--quiet", "HEAD"],
+        cwd=git_cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-                # Get the commit message from the reference
-                ref_message_result = await run_command(
-                    ["git", "log", "-1", "--pretty=%B", ref_name],
-                    cwd=git_cwd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                ref_message = ref_message_result.stdout.strip()
-
-                # Create a new commit with the same tree as HEAD but message from the reference
-                # This effectively creates the commit without changing the working tree
-                new_commit_result = await run_command(
-                    [
-                        "git",
-                        "commit-tree",
-                        tree_hash,
-                        "-p",
-                        head_hash,
-                        "-m",
-                        ref_message,
-                    ],
-                    cwd=git_cwd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                new_commit_hash = new_commit_result.stdout.strip()
-
-                # Update HEAD to point to the new commit
-                await run_command(
-                    ["git", "update-ref", "HEAD", new_commit_hash],
-                    cwd=git_cwd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-
-                logging.info(
-                    f"Successfully applied reference commit for chat ID {chat_id}"
-                )
-                # After applying, the HEAD commit should have the right chat_id
-                head_chat_id = await get_head_commit_chat_id(git_cwd)
-
-        assert head_chat_id == chat_id, (
-            "This usually fails because you didn't InitProject before interacting with codemcp"
-        )
-
-        # Get the current commit hash before amending
-        commit_hash = await get_head_commit_hash(git_cwd)
-
-        # Get the current commit message
-        current_commit_message = await get_head_commit_message(git_cwd)
-
-        # Verify the commit has our codemcp-id
-        if chat_id and "codemcp-id: " not in current_commit_message:
-            logging.warning("Expected codemcp-id in current commit but not found")
-
-        # Use the update function for subsequent edits
-        commit_message = update_commit_message_with_description(
-            current_commit_message=current_commit_message,
-            description=description,
-            commit_hash=commit_hash,
-        )
-
-        # Amend the previous commit
-        commit_result = await run_command(
-            ["git", "commit", "--amend", "-m", commit_message],
-            cwd=git_cwd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        if commit_result.returncode != 0:
-            return False, f"Failed to commit changes: {commit_result.stderr}"
-
-        # If this was an amended commit, include the original hash in the message
+    # If diff-index returns 0, there are no changes to commit
+    if diff_result.returncode == 0:
         return (
             True,
-            f"Changes {verb} successfully (previous commit was {commit_hash})",
+            "No changes to commit (changes already committed or no changes detected)",
         )
-    except Exception:
-        raise
+
+    # Determine whether to amend or create a new commit
+    head_chat_id = await get_head_commit_chat_id(git_cwd)
+    logging.debug(
+        "commit_changes: head_chat_id = %s",
+        head_chat_id,
+    )
+
+    verb = "amended"
+
+    # If HEAD exists but doesn't have the right chat_id, check if we have a
+    # commit reference for this chat_id that we need to cherry-pick first
+    if head_chat_id != chat_id:
+        verb = "committed"
+        ref_name = f"refs/codemcp/{chat_id}"
+        ref_exists = False
+
+        # Check if the reference exists
+        ref_result = await run_command(
+            ["git", "show-ref", "--verify", ref_name],
+            cwd=git_cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        ref_exists = ref_result.returncode == 0
+
+        if ref_exists:
+            # Using git plumbing commands instead of cherry-pick to avoid conflicts with local changes
+            logging.info(f"Creating a new commit from reference {ref_name}")
+
+            # Get the current HEAD commit hash
+            head_hash = await get_head_commit_hash(git_cwd, short=False)
+
+            # Get the tree from HEAD
+            tree_result = await run_command(
+                ["git", "show", "-s", "--format=%T", "HEAD"],
+                cwd=git_cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            tree_hash = tree_result.stdout.strip()
+
+            # Get the commit message from the reference
+            ref_message_result = await run_command(
+                ["git", "log", "-1", "--pretty=%B", ref_name],
+                cwd=git_cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            ref_message = ref_message_result.stdout.strip()
+
+            # Create a new commit with the same tree as HEAD but message from the reference
+            # This effectively creates the commit without changing the working tree
+            new_commit_result = await run_command(
+                [
+                    "git",
+                    "commit-tree",
+                    tree_hash,
+                    "-p",
+                    head_hash,
+                    "-m",
+                    ref_message,
+                ],
+                cwd=git_cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            new_commit_hash = new_commit_result.stdout.strip()
+
+            # Update HEAD to point to the new commit
+            await run_command(
+                ["git", "update-ref", "HEAD", new_commit_hash],
+                cwd=git_cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            logging.info(f"Successfully applied reference commit for chat ID {chat_id}")
+            # After applying, the HEAD commit should have the right chat_id
+            head_chat_id = await get_head_commit_chat_id(git_cwd)
+
+    assert head_chat_id == chat_id, (
+        "This usually fails because you didn't InitProject before interacting with codemcp"
+    )
+
+    # Get the current commit hash before amending
+    commit_hash = await get_head_commit_hash(git_cwd)
+
+    # Get the current commit message
+    current_commit_message = await get_head_commit_message(git_cwd)
+
+    # Verify the commit has our codemcp-id
+    if chat_id and "codemcp-id: " not in current_commit_message:
+        logging.warning("Expected codemcp-id in current commit but not found")
+
+    # Use the update function for subsequent edits
+    commit_message = update_commit_message_with_description(
+        current_commit_message=current_commit_message,
+        description=description,
+        commit_hash=commit_hash,
+    )
+
+    # Amend the previous commit
+    commit_result = await run_command(
+        ["git", "commit", "--amend", "-m", commit_message],
+        cwd=git_cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if commit_result.returncode != 0:
+        return False, f"Failed to commit changes: {commit_result.stderr}"
+
+    # If this was an amended commit, include the original hash in the message
+    return (
+        True,
+        f"Changes {verb} successfully (previous commit was {commit_hash})",
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132
* #131
* #130
* __->__ #129
* #128
* #124
* #123
* #122
* #121

commit_changes has a pointless try...except and then immediately raise.

```git-revs
74eb72a  (Base revision)
9c5df57  Removed redundant try-except in commit_changes function
HEAD     Auto-commit format changes
```

codemcp-id: 153-fix-remove-redundant-try-except-in-commit-changes-