### PR TITLE
refactor: pass Git root directory as argument to tools

### DIFF
--- a/codemcp/tools/file_utils.py
+++ b/codemcp/tools/file_utils.py
@@ -39,13 +39,16 @@ async def check_file_path_and_permissions(file_path: str) -> tuple[bool, str | N
 
 
 async def check_git_tracking_for_existing_file(
+    git_root: str,
     file_path: str,
     chat_id: str,
 ) -> tuple[bool, str | None]:
     """Check if an existing file is tracked by git. Skips check for non-existent files.
 
     Args:
+        git_root: The root directory of the Git repository
         file_path: The absolute path to the file
+        chat_id: The unique ID of the current chat session
 
     Returns:
         A tuple of (success, error_message)
@@ -79,6 +82,7 @@ async def check_git_tracking_for_existing_file(
 
         # If there are other uncommitted changes, commit them
         commit_success, commit_message = await commit_changes(
+            git_root,
             file_path,
             description="Snapshot before codemcp change",
             chat_id=chat_id,

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -17,6 +17,7 @@ __all__ = [
 
 
 async def read_file_content(
+    git_root: str,
     file_path: str,
     offset: int | None = None,
     limit: int | None = None,
@@ -25,6 +26,7 @@ async def read_file_content(
     """Read a file's content with optional offset and limit.
 
     Args:
+        git_root: The root directory of the Git repository
         file_path: The absolute path to the file to read
         offset: The line number to start reading from (1-indexed)
         limit: The number of lines to read
@@ -97,11 +99,9 @@ async def read_file_content(
         content += f"\n... (file truncated, showing {len(processed_lines)} of {total_lines} lines)"
 
     # Apply relevant cursor rules
-    # Find git repository root
-    repo_root = find_git_root(os.path.dirname(full_file_path))
-
-    if repo_root:
+    # Use the provided git root
+    if git_root:
         # Add applicable rules content
-        content += get_applicable_rules_content(repo_root, full_file_path)
+        content += get_applicable_rules_content(git_root, full_file_path)
 
     return content

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -84,11 +84,12 @@ def detect_repo_line_endings(directory: str) -> str:
 
 
 async def write_file_content(
-    file_path: str, content: str, description: str = "", chat_id: str = None
+    git_root: str, file_path: str, content: str, description: str = "", chat_id: str = None
 ) -> str:
     """Write content to a file.
 
     Args:
+        git_root: The root directory of the Git repository
         file_path: The absolute path to the file to write
         content: The content to write to the file
         description: Short description of the change
@@ -132,7 +133,7 @@ async def write_file_content(
 
     # Commit the changes
     git_message = ""
-    success, message = await commit_changes(file_path, description, chat_id)
+    success, message = await commit_changes(git_root, file_path, description, chat_id)
     if success:
         git_message = f"\nChanges committed to git: {description}"
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132
* __->__ #131
* #130
* #129
* #128
* #124
* #123
* #122
* #121

I want you to do a refactor. The idea is that we want to make every tool implementation in tools/ take an extra argument at the start which is the Git root directory. We compute the root directory in main.py off of path once and then pass it in everywhere. Do the refactor in two phases. First, adjust all the tool calls to have a new argument and pass it in from main.py. Second, adjust the implementations to directly make use of the argument instead of recomputing it from scratch. You may have to plumb this argument into helper functions. Don't be lazy.

```git-revs
8e74736  (Base revision)
012e0a8  Add import for get_repository_root
9b91d40  Update ReadFile subtool to compute and pass git_root parameter
6cbc0ec  Update WriteFile subtool to compute and pass git_root parameter
dbf405a  Update EditFile subtool to compute and pass git_root parameter
5f8243a  Update LS subtool to compute and pass git_root parameter
f4d71fd  Add comment explaining why InitProject doesn't need git_root computed
ebe5f06  Update RunCommand subtool to compute and pass git_root parameter
eb4393b  Update Grep subtool to compute and pass git_root parameter
ddc683f  Update Glob subtool to compute and pass git_root parameter
4aa3402  Add comment explaining why UserPrompt doesn't need git_root
4453ca1  Update read_file_content function to accept git_root parameter
babec9c  Use provided git_root parameter instead of computing it
a357ba1  Update write_file_content function to accept git_root parameter
0be7606  Update commit_changes call to pass git_root
2361132  Update check_git_tracking_for_existing_file function signature to accept git_root
HEAD     Update commit_changes call to pass git_root
```

codemcp-id: 155-refactor-pass-git-root-directory-as-argument-to-to