### PR TITLE
refactor: add Git root dir parameter to all tool implementations

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -145,7 +145,7 @@ async def codemcp(
         if subtool == "ReadFile":
             if path is None:
                 raise ValueError("path is required for ReadFile subtool")
-                
+
             # Get the git repository root
             git_root = await get_repository_root(path)
 
@@ -161,7 +161,9 @@ async def codemcp(
             git_root = await get_repository_root(path)
 
             content_str = content or ""
-            return await write_file_content(git_root, path, content_str, description, chat_id)
+            return await write_file_content(
+                git_root, path, content_str, description, chat_id
+            )
 
         if subtool == "EditFile":
             if path is None:

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -20,6 +20,7 @@ MAX_RESULTS = 100
 
 
 async def glob(
+    git_root: str,
     pattern: str,
     path: str,
     options: Optional[Dict[str, Any]] = None,
@@ -28,6 +29,7 @@ async def glob(
     """Find files matching a glob pattern.
 
     Args:
+        git_root: The root directory of the Git repository
         pattern: The glob pattern to match files against
         path: The directory to search in
         options: Optional parameters for pagination (limit, offset)
@@ -151,6 +153,7 @@ def render_result_for_assistant(output: Dict[str, Any]) -> str:
 
 
 async def glob_files(
+    git_root: str,
     pattern: str,
     path: str | None = None,
     limit: int = MAX_RESULTS,
@@ -161,6 +164,7 @@ async def glob_files(
     """Search for files matching a glob pattern.
 
     Args:
+        git_root: The root directory of the Git repository
         pattern: The glob pattern to match files against
         path: The directory to search in (defaults to current working directory)
         limit: Maximum number of results to return
@@ -184,7 +188,7 @@ async def glob_files(
     }
 
     # Execute glob
-    result = await glob(pattern, path, options, signal)
+    result = await glob(git_root, pattern, path, options, signal)
 
     # Calculate execution time
     execution_time = int((time.time() - start_time) * 1000)  # Convert to milliseconds

--- a/codemcp/tools/grep.py
+++ b/codemcp/tools/grep.py
@@ -7,7 +7,6 @@ import time
 from typing import Any
 
 from ..common import normalize_file_path
-from ..git import is_git_repository
 from ..shell import run_command
 
 __all__ = [
@@ -34,6 +33,7 @@ Example:
 
 
 async def git_grep(
+    git_root: str,
     pattern: str,
     path: str | None = None,
     include: str | None = None,
@@ -42,6 +42,7 @@ async def git_grep(
     """Execute git grep to search for pattern in files.
 
     Args:
+        git_root: The root directory of the Git repository
         pattern: The regular expression pattern to search for
         path: The directory or file to search in (must be in a git repository)
         include: Optional file pattern to filter the search
@@ -57,9 +58,7 @@ async def git_grep(
     # Normalize the directory path
     absolute_path = normalize_file_path(path)
 
-    # Verify this is a git repository - this check uses the mocked version in tests
-    if not await is_git_repository(absolute_path):
-        raise ValueError(f"The provided path is not in a git repository: {path}")
+    # No need to verify if this is a git repository since we already have git_root
 
     # In non-test environment, verify the path exists
     if not os.environ.get("DESKAID_TESTING"):
@@ -157,6 +156,7 @@ def render_result_for_assistant(output: dict[str, Any]) -> str:
 
 
 async def grep_files(
+    git_root: str,
     pattern: str,
     path: str | None = None,
     include: str | None = None,
@@ -166,6 +166,7 @@ async def grep_files(
     """Search for a pattern in files within a directory or in a specific file.
 
     Args:
+        git_root: The root directory of the Git repository
         pattern: The regular expression pattern to search for
         path: The directory or file to search in (must be in a git repository)
         include: Optional file pattern to filter the search
@@ -179,7 +180,7 @@ async def grep_files(
     start_time = time.time()
 
     # Execute git grep asynchronously
-    matches = await git_grep(pattern, path, include, signal)
+    matches = await git_grep(git_root, pattern, path, include, signal)
 
     # Sort matches
     try:

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -8,7 +8,6 @@ from ..common import (
     MAX_OUTPUT_SIZE,
     normalize_file_path,
 )
-from ..git_query import find_git_root
 from ..rules import get_applicable_rules_content
 
 __all__ = [

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -84,7 +84,11 @@ def detect_repo_line_endings(directory: str) -> str:
 
 
 async def write_file_content(
-    git_root: str, file_path: str, content: str, description: str = "", chat_id: str = None
+    git_root: str,
+    file_path: str,
+    content: str,
+    description: str = "",
+    chat_id: str = None,
 ) -> str:
     """Write content to a file.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132
* #131
* #130
* #129
* #128
* #124
* #123
* #122
* #121

I want you to do a refactor. The idea is that we want to make every tool implementation in tools/ take an extra argument at the start which is the Git root directory. We compute the root directory in main.py off of path once and then pass it in everywhere. Do the refactor in two phases. First, adjust all the tool calls to have a new argument and pass it in from main.py. Second, adjust the implementations to directly make use of the argument instead of recomputing it from scratch. You may have to plumb this argument into helper functions. Don't be lazy.

```git-revs
01e2ed8  (Base revision)
5a44f7f  Update glob_files function to accept git_root parameter
fe12c5d  Update grep_files function to accept git_root parameter
734bba8  Update ls_directory function to accept git_root parameter
41341d4  Fix ls_directory function and move try-except to the correct location
29e9dce  Remove redundant is_git_repository check in ls_directory
b5f6e5a  Update git_grep function to accept git_root parameter and remove redundant check
3f039c3  Update grep_files to pass git_root to git_grep
bd3021f  Update glob function to accept git_root parameter
2ed1f38  Update glob_files to pass git_root to glob
bab215b  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 156-refactor-add-git-root-dir-parameter-to-all-tool-im