### PR TITLE
refactor: use codemcp.main.codemcp directly instead of client session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Look at codemcp.toml for a system prompt, as well as how to run various commands.

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp import FastMCP
 
 from .tools.edit_file import edit_file_content
 from .tools.glob import MAX_RESULTS, glob_files

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -208,15 +208,11 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         subtool = tool_params.get("subtool")
         kwargs = {k: v for k, v in tool_params.items() if k != "subtool"}
 
-        try:
-            # Call codemcp.main.codemcp directly instead of using the client session
-            result = await codemcp.main.codemcp(subtool, **kwargs)
-            # Return the normalized, extracted text result
-            normalized_result = self.normalize_path(result)
-            return self.extract_text_from_result(normalized_result)
-        except Exception as e:
-            # The call failed - but we expected it to succeed
-            self.fail(f"Tool call to {tool_name} failed with error: {str(e)}")
+        # Call codemcp.main.codemcp directly instead of using the client session
+        result = await codemcp.main.codemcp(subtool, **kwargs)
+        # Return the normalized, extracted text result
+        normalized_result = self.normalize_path(result)
+        return self.extract_text_from_result(normalized_result)
 
     async def get_chat_id(self, session):
         """Initialize project and get chat_id.

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -141,44 +141,54 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         """Call a tool and assert that it fails (isError=True).
 
         This is a helper method for the error path of tool calls, which:
-        1. Calls the specified tool with the given parameters
-        2. Asserts that the result is an error
-        3. Returns the extracted text result
+        1. Calls the specified tool with the given parameters using codemcp.main.codemcp directly
+        2. Asserts that the call raises an exception
+        3. Returns the exception string
 
         Args:
-            session: The client session to use
-            tool_name: The name of the tool to call
+            session: The client session to use (kept for backward compatibility but unused)
+            tool_name: The name of the tool to call (must be 'codemcp')
             tool_params: Dictionary of parameters to pass to the tool
 
         Returns:
-            str: The extracted text content from the result
+            str: The extracted error message
 
         Raises:
             AssertionError: If the tool call does not result in an error
         """
-        result = await session.call_tool(tool_name, tool_params)
+        import codemcp.main
 
-        # Check that the result is an error
-        self.assertTrue(
-            getattr(result, "isError", False),
-            f"Tool call to {tool_name} succeeded, expected to fail",
+        # Only codemcp tool is supported
+        assert tool_name == "codemcp", (
+            f"Only 'codemcp' tool is supported, got '{tool_name}'"
         )
 
-        # Return the normalized, extracted text result
-        normalized_result = self.normalize_path(result)
-        return self.extract_text_from_result(normalized_result)
+        # Extract the parameters to pass to codemcp.main.codemcp
+        subtool = tool_params.get("subtool")
+        kwargs = {k: v for k, v in tool_params.items() if k != "subtool"}
+
+        try:
+            # Call codemcp.main.codemcp directly instead of using the client session
+            await codemcp.main.codemcp(subtool, **kwargs)
+            # If we get here, the call succeeded - but we expected it to fail
+            self.fail(f"Tool call to {tool_name} succeeded, expected to fail")
+        except Exception as e:
+            # The call failed as expected - return the error message
+            error_message = f"Error executing tool {tool_name}: {str(e)}"
+            normalized_result = self.normalize_path(error_message)
+            return normalized_result
 
     async def call_tool_assert_success(self, session, tool_name, tool_params):
         """Call a tool and assert that it succeeds (isError=False).
 
         This is a helper method for the happy path of tool calls, which:
-        1. Calls the specified tool with the given parameters
-        2. Asserts that the result is not an error
-        3. Returns the extracted text result
+        1. Calls the specified tool with the given parameters using codemcp.main.codemcp directly
+        2. Asserts that the call succeeds (no exception)
+        3. Returns the result text
 
         Args:
-            session: The client session to use
-            tool_name: The name of the tool to call
+            session: The client session to use (kept for backward compatibility but unused)
+            tool_name: The name of the tool to call (must be 'codemcp')
             tool_params: Dictionary of parameters to pass to the tool
 
         Returns:
@@ -187,39 +197,46 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         Raises:
             AssertionError: If the tool call results in an error
         """
-        result = await session.call_tool(tool_name, tool_params)
+        import codemcp.main
 
-        # Check that the result is not an error
-        self.assertFalse(
-            getattr(result, "isError", False),
-            f"Tool call to {tool_name} failed with error: {self.extract_text_from_result(result)}",
+        # Only codemcp tool is supported
+        assert tool_name == "codemcp", (
+            f"Only 'codemcp' tool is supported, got '{tool_name}'"
         )
 
-        # Return the normalized, extracted text result
-        normalized_result = self.normalize_path(result)
-        return self.extract_text_from_result(normalized_result)
+        # Extract the parameters to pass to codemcp.main.codemcp
+        subtool = tool_params.get("subtool")
+        kwargs = {k: v for k, v in tool_params.items() if k != "subtool"}
+
+        try:
+            # Call codemcp.main.codemcp directly instead of using the client session
+            result = await codemcp.main.codemcp(subtool, **kwargs)
+            # Return the normalized, extracted text result
+            normalized_result = self.normalize_path(result)
+            return self.extract_text_from_result(normalized_result)
+        except Exception as e:
+            # The call failed - but we expected it to succeed
+            self.fail(f"Tool call to {tool_name} failed with error: {str(e)}")
 
     async def get_chat_id(self, session):
         """Initialize project and get chat_id.
 
         Args:
-            session: The client session to use
+            session: The client session to use (kept for backward compatibility but unused)
 
         Returns:
             str: The chat_id
         """
-        # First initialize project to get chat_id
-        init_result = await session.call_tool(
-            "codemcp",
-            {
-                "subtool": "InitProject",
-                "path": self.temp_dir.name,
-                "user_prompt": "Test initialization for get_chat_id",
-                "subject_line": "test: initialize for e2e testing",
-                "reuse_head_chat_id": False,
-            },
+        import codemcp.main
+
+        # First initialize project to get chat_id using codemcp.main.codemcp directly
+        init_result_text = await codemcp.main.codemcp(
+            "InitProject",
+            path=self.temp_dir.name,
+            user_prompt="Test initialization for get_chat_id",
+            subject_line="test: initialize for e2e testing",
+            reuse_head_chat_id=False,
         )
-        init_result_text = self.extract_text_from_result(init_result)
 
         # Extract chat_id from the init result
         import re

--- a/e2e/test_read_file.py
+++ b/e2e/test_read_file.py
@@ -53,8 +53,8 @@ class ReadFileTest(MCPEndToEndTestCase):
                 {
                     "subtool": "ReadFile",
                     "path": test_file_path,
-                    "offset": "2",  # Start from line 2
-                    "limit": "2",  # Read 2 lines
+                    "offset": 2,  # Start from line 2
+                    "limit": 2,  # Read 2 lines
                     "chat_id": chat_id,
                 },
             )

--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -92,7 +92,7 @@ test: initialize for write file test
 Test initialization for write_file test
 
 ```git-revs
-c9bcf9c  (Base revision)
+8288c39  (Base revision)
 HEAD     Create new file
 ```
 
@@ -151,8 +151,8 @@ test: initialize for write file test
 Test initialization for write_file test
 
 ```git-revs
-c9bcf9c  (Base revision)
-a0816d8  Create new file
+8288c39  (Base revision)
+8570039  Create new file
 HEAD     Update file with third line
 ```
 
@@ -464,7 +464,7 @@ Markdown to send to LLM
 And make sure it runs correctly.
 
 ```git-revs
-6350984  (Base revision)
+5d9edac  (Base revision)
 HEAD     Write file from prompt with code block
 ```
 
@@ -523,8 +523,8 @@ Markdown to send to LLM
 And make sure it runs correctly.
 
 ```git-revs
-6350984  (Base revision)
-9071fd5  Write file from prompt with code block
+5d9edac  (Base revision)
+85999d0  Write file from prompt with code block
 HEAD     Update file with second write
 ```
 

--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -92,7 +92,7 @@ test: initialize for write file test
 Test initialization for write_file test
 
 ```git-revs
-8288c39  (Base revision)
+9b56861  (Base revision)
 HEAD     Create new file
 ```
 
@@ -151,8 +151,8 @@ test: initialize for write file test
 Test initialization for write_file test
 
 ```git-revs
-8288c39  (Base revision)
-8570039  Create new file
+9b56861  (Base revision)
+00fd36b  Create new file
 HEAD     Update file with third line
 ```
 
@@ -464,7 +464,7 @@ Markdown to send to LLM
 And make sure it runs correctly.
 
 ```git-revs
-5d9edac  (Base revision)
+f0a515e  (Base revision)
 HEAD     Write file from prompt with code block
 ```
 
@@ -523,8 +523,8 @@ Markdown to send to LLM
 And make sure it runs correctly.
 
 ```git-revs
-5d9edac  (Base revision)
-85999d0  Write file from prompt with code block
+f0a515e  (Base revision)
+8e46d55  Write file from prompt with code block
 HEAD     Update file with second write
 ```
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135
* __->__ #134
* #133

Modify call_tool_assert_success and call_tool_assert_error to use codemcp.main.codemcp directly

```git-revs
2d8d25d  (Base revision)
25dab21  Update call_tool_assert_success and call_tool_assert_error to use codemcp.main.codemcp directly
a2f28ab  Update get_chat_id to use codemcp.main.codemcp directly
7f32835  Snapshot before auto-format
21d60a1  Auto-commit format changes
d12e624  Auto-commit lint changes
HEAD     Auto-commit accept changes
```

codemcp-id: 157-refactor-use-codemcp-main-codemcp-directly-instead