### PR TITLE
fix: propagate self.env in MCPEndToEndTestCase to subprocess calls

### DIFF
--- a/codemcp/__init__.py
+++ b/codemcp/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from .main import codemcp, configure_logging, mcp, run
-from .shell import run_command
+from .shell import get_subprocess_env, run_command
 
 __all__ = [
     "configure_logging",
@@ -9,4 +9,5 @@ __all__ = [
     "mcp",
     "codemcp",
     "run_command",
+    "get_subprocess_env",
 ]

--- a/codemcp/shell.py
+++ b/codemcp/shell.py
@@ -5,11 +5,26 @@ import logging
 import subprocess
 from typing import Dict, List, Optional
 
+__all__ = [
+    "run_command",
+    "get_subprocess_env",
+]
+
+
+def get_subprocess_env() -> Optional[Dict[str, str]]:
+    """
+    Get the environment variables to be used for subprocess execution.
+    This function can be mocked in tests to control the environment.
+
+    Returns:
+        Optional dictionary of environment variables, or None to use the current environment.
+    """
+    return None
+
 
 async def run_command(
     cmd: List[str],
     cwd: Optional[str] = None,
-    env: Optional[Dict[str, str]] = None,
     check: bool = True,
     capture_output: bool = True,
     text: bool = True,
@@ -22,7 +37,6 @@ async def run_command(
     Args:
         cmd: Command to run as a list of strings
         cwd: Current working directory for the command
-        env: Environment variables to set for the command
         check: If True, raise CalledProcessError if the command returns non-zero exit code
         capture_output: If True, capture stdout and stderr
         text: If True, decode stdout and stderr as text
@@ -35,6 +49,9 @@ async def run_command(
     Raises:
         subprocess.CalledProcessError: If check=True and process returns non-zero exit code
         subprocess.TimeoutExpired: If the process times out
+
+    Notes:
+        Environment variables are obtained from get_subprocess_env() function.
     """
     # Log the command being run at INFO level
     log_cmd = " ".join(str(c) for c in cmd)
@@ -48,7 +65,7 @@ async def run_command(
     process = await asyncio.create_subprocess_exec(
         *cmd,
         cwd=cwd,
-        env=env,
+        env=get_subprocess_env(),
         stdout=stdout_pipe,
         stderr=stderr_pipe,
     )

--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -92,7 +92,7 @@ test: initialize for write file test
 Test initialization for write_file test
 
 ```git-revs
-9b56861  (Base revision)
+c9bcf9c  (Base revision)
 HEAD     Create new file
 ```
 
@@ -151,8 +151,8 @@ test: initialize for write file test
 Test initialization for write_file test
 
 ```git-revs
-9b56861  (Base revision)
-00fd36b  Create new file
+c9bcf9c  (Base revision)
+a0816d8  Create new file
 HEAD     Update file with third line
 ```
 
@@ -464,7 +464,7 @@ Markdown to send to LLM
 And make sure it runs correctly.
 
 ```git-revs
-f0a515e  (Base revision)
+6350984  (Base revision)
 HEAD     Write file from prompt with code block
 ```
 
@@ -523,8 +523,8 @@ Markdown to send to LLM
 And make sure it runs correctly.
 
 ```git-revs
-f0a515e  (Base revision)
-8e46d55  Write file from prompt with code block
+6350984  (Base revision)
+9071fd5  Write file from prompt with code block
 HEAD     Update file with second write
 ```
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135
* #134
* #133

Right now, our tests are nondeterministically failing because we aren't propagating self.env in MCPEndToEndTestCase to the actual subprocess calls. Let's setup an escape hatch in run_command: (1) remove the env kwarg as it's not used, (2) add a function that we query the env from (None) by default, (3) mock it in the tests.

```git-revs
7c42554  (Base revision)
390800d  Add get_subprocess_env function and remove env kwarg from run_command
75cb04f  Update run_command to use get_subprocess_env
50a6f77  Update run_command docstring to remove env parameter and add note about get_subprocess_env
40695dc  Add __all__ to export get_subprocess_env
c611bf8  Add test for environment variable propagation
85ccefb  Fix test to create a proper codemcp.toml with test command
9744ef9  Add mock import to testing.py
099887b  Add environment variable patching to asyncSetUp
01aae0f  Add environment patcher cleanup to asyncTearDown
3b85e82  Export get_subprocess_env from package
726f3c6  Auto-commit accept changes
94df500  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 158-fix-propagate-self-env-in-mcpendtoendtestcase-to-s