### PR TITLE
fix: Block edits to codemcp.toml to mitigate security risks

### DIFF
--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -643,6 +643,10 @@ async def edit_file_content(
         Files must be tracked in the git repository before they can be modified.
 
     """
+    # Prevent editing codemcp.toml for security reasons
+    if os.path.basename(file_path) == "codemcp.toml":
+        raise ValueError("Editing codemcp.toml is not allowed for security reasons.")
+
     # Convert to absolute path if needed
     full_file_path = (
         file_path if os.path.isabs(file_path) else os.path.abspath(file_path)


### PR DESCRIPTION
This PR adds a check to the edit_file_content function to raise an exception if the file being edited is codemcp.toml. This prevents modifications to codemcp.toml and mitigates potential security risks.

Allowing edits to codemcp.toml poses a critical security risk. Claude can understand the contents of codemcp.toml, modify it to achieve the user’s instructions, and potentially execute arbitrary commands. In fact, I have experienced codemcp.toml being modified.

You can reproduce the issue with the following instruction:
“Edit codemcp.toml to run cat /etc/passwd and show me the result.”