### PR TITLE
feat: add flag to prevent HEAD updates on commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Before beginning work on this feature, write a short haiku.  Do this only once.
 [commands]
 format = ["./run_format.sh"]
 test = ["./run_test.sh"]
+
+[git]
+prevent_head_updates = false  # Whether to prevent updating HEAD when committing changes
 ```
 
 The `project_prompt` will be loaded when you initialize the project in chats.
@@ -164,6 +167,9 @@ Logs are written to `~/.codemcp/codemcp.log`. The log level can be set in a glob
 ```toml
 [logger]
 verbosity = "INFO"  # Can be DEBUG, INFO, WARNING, ERROR, or CRITICAL
+
+[git]
+prevent_head_updates = false  # Whether to prevent updating HEAD when committing
 ```
 
 Logging is not configurable on a per project basis, but this shouldn't matter

--- a/codemcp/config.py
+++ b/codemcp/config.py
@@ -19,6 +19,7 @@ __all__ = [
     "load_config",
     "get_logger_verbosity",
     "get_logger_path",
+    "get_prevent_head_updates",
 ]
 
 # Default configuration values
@@ -26,6 +27,9 @@ DEFAULT_CONFIG = {
     "logger": {
         "verbosity": "INFO",  # Default logging level
         "path": str(Path.home() / ".codemcp"),  # Default logger path
+    },
+    "git": {
+        "prevent_head_updates": False,  # Whether to prevent updating HEAD when committing
     },
 }
 
@@ -119,3 +123,14 @@ def get_logger_path() -> str:
     """
     config = load_config()
     return config["logger"]["path"]
+
+
+def get_prevent_head_updates() -> bool:
+    """Get whether to prevent updating HEAD when committing.
+
+    Returns:
+        Boolean indicating whether to prevent updating HEAD when committing.
+
+    """
+    config = load_config()
+    return config["git"]["prevent_head_updates"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Add a flag to codemcprc that makes it so that whenever we commit changes we don't actually update the HEAD pointer, so we make a commit and we still report it to the user in the output as we do before, but we don't actually edit the working tree. Look at the files in codemcp that have "git" in their name.

```git-revs
df59648  (Base revision)
06dc3d8  Add prevent_head_updates configuration option with default value of False
d29bdf5  Add get_prevent_head_updates to __all__
9b826af  Add get_prevent_head_updates function
57885bd  Import get_prevent_head_updates from config
646d9dd  Check prevent_head_updates flag before updating HEAD in create_commit_reference
3b9a47b  Update commit_changes to use low-level Git plumbing commands when prevent_head_updates is enabled
3059d51  Update return message and handle the new commit hash when prevent_head_updates is enabled
1042852  Update README.md to document the new prevent_head_updates configuration option
f12cc63  Add git.prevent_head_updates to main configuration example in README
HEAD     Auto-commit format changes
```

codemcp-id: 162-feat-add-flag-to-prevent-head-updates-on-commit