### PR TITLE
fix: investigate Windows line ending issue in WriteFile

### DIFF
--- a/codemcp/tools/file_utils.py
+++ b/codemcp/tools/file_utils.py
@@ -159,5 +159,7 @@ def write_file_sync(file_path: str, content: str, encoding: str = "utf-8") -> No
         content: The content to write
         encoding: The encoding to use
     """
-    with open(file_path, "w", encoding=encoding) as f:
-        f.write(content)
+    # Use binary mode ('wb') to avoid Python's automatic newline translation
+    # This prevents double-translation of line endings on Windows
+    with open(file_path, "wb") as f:
+        f.write(content.encode(encoding))

--- a/e2e/test_disable_git_commit.py
+++ b/e2e/test_disable_git_commit.py
@@ -3,9 +3,7 @@
 """Tests for the disable_git_commit configuration option."""
 
 import os
-import sys
 import unittest
-import re
 
 from codemcp import config
 from codemcp.testing import MCPEndToEndTestCase
@@ -262,7 +260,7 @@ class DisableGitCommitTest(MCPEndToEndTestCase):
 
             try:
                 # First edit with disable_git_commit=True
-                result1_text = await self.call_tool_assert_success(
+                await self.call_tool_assert_success(
                     session,
                     "codemcp",
                     {
@@ -295,7 +293,7 @@ class DisableGitCommitTest(MCPEndToEndTestCase):
                 )
 
                 # Second edit with the same chat_id
-                result2_text = await self.call_tool_assert_success(
+                await self.call_tool_assert_success(
                     session,
                     "codemcp",
                     {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Users on Windows reported that when codemcp writes files it adds extra spaces in between lines of code. I'm not too sure why this happens. Read the code for WriteFile tool and carefully think about might occur. You cannot test the problem here as we are not on Windows, so be confident about your fix or discuss it with me.

```git-revs
000cccb  (Base revision)
846792c  Fix Windows line ending issue by using binary mode for file write
HEAD     Auto-commit lint changes
```

codemcp-id: 163-fix-investigate-windows-line-ending-issue-in-write