### PR TITLE
fix: normalize string inputs to \n newlines

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -99,6 +99,21 @@ async def codemcp(
         if isinstance(arguments, str):
             arguments = [arguments]
 
+        # Normalize string inputs to ensure consistent newlines
+        def normalize_newlines(s):
+            """Normalize string to use \n for all newlines."""
+            return s.replace("\r\n", "\n") if isinstance(s, str) else s
+
+        # Normalize content, old_string, and new_string to use consistent \n newlines
+        content = normalize_newlines(content)
+        old_string = normalize_newlines(old_string)
+        new_string = normalize_newlines(new_string)
+        # Also normalize backward compatibility parameters
+        old_str = normalize_newlines(old_str)
+        new_str = normalize_newlines(new_str)
+        # And user prompt which might contain code blocks
+        user_prompt = normalize_newlines(user_prompt)
+
         # Get all provided non-None parameters
         provided_params = {
             param: value

--- a/e2e/test_disable_git_commit.py
+++ b/e2e/test_disable_git_commit.py
@@ -3,9 +3,7 @@
 """Tests for the disable_git_commit configuration option."""
 
 import os
-import sys
 import unittest
-import re
 
 from codemcp import config
 from codemcp.testing import MCPEndToEndTestCase
@@ -262,7 +260,7 @@ class DisableGitCommitTest(MCPEndToEndTestCase):
 
             try:
                 # First edit with disable_git_commit=True
-                result1_text = await self.call_tool_assert_success(
+                await self.call_tool_assert_success(
                     session,
                     "codemcp",
                     {
@@ -295,7 +293,7 @@ class DisableGitCommitTest(MCPEndToEndTestCase):
                 )
 
                 # Second edit with the same chat_id
-                result2_text = await self.call_tool_assert_success(
+                await self.call_tool_assert_success(
                     session,
                     "codemcp",
                     {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #150
* #147

String inputs to codemcp in main.py are not guaranteed to have \n newlines and may be \r\n. Add logic in main.py to ensure they are all normalized to \n (if necessary) so that all later writes using universal newlines have correct semantics. Avoid duplicating logic and write the change compactly.

```git-revs
b772a7a  (Base revision)
8d3c5c3  Normalize string inputs to \n newlines
6c2a7af  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 164-fix-normalize-string-inputs-to-n-newlines