### PR TITLE
feat: update RunCommand to interpret space-separated strings as shell-style arguments

### DIFF
--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -375,8 +375,8 @@ Example:
 
 Runs a command.  This does NOT support arbitrary code execution, ONLY call
 with this set of valid commands: {command_help}
-When a single string is passed as arguments, it will be interpreted as space-separated 
-arguments using shell-style tokenization (spaces separate arguments, quotes can be used 
+When a single string is passed as arguments, it will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
 for arguments containing spaces, etc.).
 {_generate_command_docs(command_docs)}
 

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -375,6 +375,9 @@ Example:
 
 Runs a command.  This does NOT support arbitrary code execution, ONLY call
 with this set of valid commands: {command_help}
+When a single string is passed as arguments, it will be interpreted as space-separated 
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used 
+for arguments containing spaces, etc.).
 {_generate_command_docs(command_docs)}
 
 ## Summary

--- a/codemcp/tools/run_command.py
+++ b/codemcp/tools/run_command.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-from typing import List, Optional
+import shlex
+from typing import List, Optional, Union
 
 from .code_command import get_command_from_config, run_code_command
 
@@ -12,7 +13,7 @@ __all__ = [
 async def run_command(
     project_dir: str,
     command: str,
-    arguments: Optional[List[str]] = None,
+    arguments: Optional[Union[List[str], str]] = None,
     chat_id: str = None,
 ) -> str:
     """Run a command that is configured in codemcp.toml.
@@ -20,7 +21,10 @@ async def run_command(
     Args:
         project_dir: The directory path containing the codemcp.toml file
         command: The type of command to run (e.g., "format", "lint", "test")
-        arguments: Optional list of arguments to pass to the command
+        arguments: Optional arguments to pass to the command. If a single string is
+                  provided, it will be parsed into a list of arguments using shell-style
+                  tokenization (spaces separate arguments, quotes can be used for arguments
+                  containing spaces, etc.)
         chat_id: The unique ID of the current chat session
 
     Returns:
@@ -31,7 +35,13 @@ async def run_command(
     # If arguments are provided, extend the command with them
     if arguments and command_list:
         command_list = command_list.copy()
-        command_list.extend(arguments)
+
+        # If a single string is provided, parse it into a list of arguments
+        if isinstance(arguments, str):
+            parsed_args = shlex.split(arguments)
+            command_list.extend(parsed_args)
+        else:
+            command_list.extend(arguments)
 
     return await run_code_command(
         project_dir, command, command_list, f"Auto-commit {command} changes", chat_id

--- a/e2e/test_run_tests.py
+++ b/e2e/test_run_tests.py
@@ -125,6 +125,124 @@ test = ["./run_test.sh"]
             self.assertIn("test_another.py", selector_result_text)
             self.assertNotIn("test_simple.py", selector_result_text)
 
+    async def test_run_tests_with_string_arguments(self):
+        """Test the RunCommand with string arguments that should be parsed."""
+        # Create a test directory for testing
+        test_dir = os.path.join(self.temp_dir.name, "test_directory")
+        os.makedirs(test_dir, exist_ok=True)
+
+        # Create a test.py file with a simple test
+        test_file_path = os.path.join(test_dir, "test_simple.py")
+        with open(test_file_path, "w") as f:
+            f.write("""
+import unittest
+
+class SimpleTestCase(unittest.TestCase):
+    def test_success(self):
+        self.assertEqual(1 + 1, 2)
+
+    def test_another_success(self):
+        self.assertTrue(True)
+""")
+
+        # Create a second test file with another test
+        test_file_path2 = os.path.join(test_dir, "test_another.py")
+        with open(test_file_path2, "w") as f:
+            f.write("""
+import unittest
+
+class AnotherTestCase(unittest.TestCase):
+    def test_success(self):
+        self.assertEqual(2 + 2, 4)
+""")
+
+        # Get the current Python executable path
+        current_python = os.path.abspath(sys.executable)
+
+        # Create run_test.sh script using the current Python executable
+        runner_script_path = os.path.join(self.temp_dir.name, "run_test.sh")
+        with open(runner_script_path, "w") as f:
+            f.write(f"""#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+{current_python} -m pytest $@
+""")
+        os.chmod(runner_script_path, 0o755)  # Make it executable
+
+        # Update codemcp.toml to include the test subtool
+        config_path = os.path.join(self.temp_dir.name, "codemcp.toml")
+        with open(config_path, "w") as f:
+            f.write("""
+[project]
+name = "test-project"
+
+[commands]
+test = ["./run_test.sh"]
+""")
+
+        # Add files to git
+        await self.git_run(["add", "."])
+        await self.git_run(["commit", "-m", "Add test files"])
+
+        async with self.create_client_session() as session:
+            # First initialize project to get chat_id
+            init_result_text = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for string arguments test",
+                    "subject_line": "test: initialize for string arguments test",
+                    "reuse_head_chat_id": False,
+                },
+            )
+
+            # Extract chat_id from the init result
+            chat_id = self.extract_chat_id_from_text(init_result_text)
+
+            # Test 1: Test with a string argument containing a specific test selector
+            # This tests the basic space-separated argument parsing
+            result_text = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "RunCommand",
+                    "path": self.temp_dir.name,
+                    "command": "test",
+                    "arguments": "test_directory/test_simple.py::SimpleTestCase::test_success",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Verify the success message and proper argument parsing
+            self.assertIn("Code test successful", result_text)
+            # We should see evidence that the test was run with the specific test case
+            self.assertIn("test_simple.py", result_text)
+            self.assertIn("1 passed", result_text)
+            # Only one test should be run due to the specific selector
+            self.assertIn("collected 1 item", result_text)
+
+            # Test 2: Test with multiple arguments separated by spaces in a single string
+            # This verifies that the string is split into multiple arguments
+            multi_arg_test = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "RunCommand",
+                    "path": self.temp_dir.name,
+                    "command": "test",
+                    "arguments": "test_directory/test_simple.py -k test_success",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Verify multiple space-separated arguments were parsed correctly
+            self.assertIn("Code test successful", multi_arg_test)
+            # Only the specific test should be run due to the -k filter
+            self.assertIn("collected 2 items", multi_arg_test)
+            self.assertIn("1 passed, 1 deselected", multi_arg_test)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #152

In RunCommand, when a single string is passed, interpret this as space separated arguments to be interpreted shell style into a list of arguments instead of only a single argument 0. Update tool desc in InitProject to indicate this semantics for string case.

```git-revs
8543cda  (Base revision)
f319181  Updated run_command to parse string arguments using shlex.split
83afe9e  Updated RunCommand description to explain string argument parsing
HEAD     Auto-commit format changes
```

codemcp-id: 167-feat-update-runcommand-to-interpret-space-separate