### PR TITLE
refactor: remove detect_file_encoding and assume UTF-8

### DIFF
--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -23,31 +23,8 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "edit_file_content",
-    "detect_file_encoding",
     "find_similar_file",
 ]
-
-
-async def detect_file_encoding(file_path: str) -> str:
-    """Detect the encoding of a file.
-
-    Args:
-        file_path: The path to the file
-
-    Returns:
-        The encoding of the file, defaults to 'utf-8'
-
-    """
-    if not os.path.exists(file_path):
-        return "utf-8"
-
-    try:
-        # Try to read with utf-8 first
-        await async_open_text(file_path, encoding="utf-8")
-        return "utf-8"
-    except UnicodeDecodeError:
-        # If utf-8 fails, default to a more permissive encoding
-        return "latin-1"
 
 
 def find_similar_file(file_path: str) -> str | None:
@@ -89,8 +66,7 @@ async def apply_edit(
 
     """
     if os.path.exists(file_path):
-        encoding = await detect_file_encoding(file_path)
-        content = await async_open_text(file_path, encoding=encoding)
+        content = await async_open_text(file_path, encoding="utf-8")
     else:
         content = ""
 
@@ -719,12 +695,11 @@ async def edit_file_content(
                 "File has been modified since read, either by the user or by a linter. Read it again before attempting to write it."
             )
 
-    # Detect encoding and line endings
-    encoding = await detect_file_encoding(full_file_path)
+    # Use UTF-8 encoding and detect line endings
     line_endings = await detect_line_endings(full_file_path, return_format="format")
 
     # Read the original file
-    content = await async_open_text(full_file_path, encoding=encoding)
+    content = await async_open_text(full_file_path, encoding="utf-8")
 
     # Check if old_string exists in the file
     if old_string and old_string not in content:
@@ -769,7 +744,7 @@ async def edit_file_content(
     os.makedirs(directory, exist_ok=True)
 
     # Write the modified content back to the file
-    await write_text_content(full_file_path, updated_file, encoding, line_endings)
+    await write_text_content(full_file_path, updated_file, "utf-8", line_endings)
 
     # Update read timestamp
     if read_file_timestamps is not None:

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import asyncio
 import os
 
 from ..git import commit_changes
@@ -13,34 +12,7 @@ from .file_utils import (
 
 __all__ = [
     "write_file_content",
-    "detect_file_encoding",
 ]
-
-
-async def detect_file_encoding(file_path: str) -> str:
-    """Detect the encoding of a file.
-
-    Args:
-        file_path: The path to the file
-
-    Returns:
-        The detected encoding, defaulting to 'utf-8'
-
-    """
-    # Simple implementation - in a real-world scenario, you might use chardet or similar
-    loop = asyncio.get_event_loop()
-
-    def read_file_utf8():
-        try:
-            with open(file_path, encoding="utf-8") as f:
-                f.read()
-            return "utf-8"
-        except UnicodeDecodeError:
-            return "latin-1"  # A safe fallback
-        except FileNotFoundError:
-            return "utf-8"
-
-    return await loop.run_in_executor(None, read_file_utf8)
 
 
 async def write_file_content(
@@ -75,9 +47,8 @@ async def write_file_content(
     if not is_tracked:
         raise ValueError(track_error)
 
-    # Determine encoding and line endings
+    # Determine line endings
     old_file_exists = os.path.exists(file_path)
-    encoding = await detect_file_encoding(file_path) if old_file_exists else "utf-8"
 
     if old_file_exists:
         line_endings = await detect_line_endings(file_path)
@@ -87,8 +58,8 @@ async def write_file_content(
         directory = os.path.dirname(file_path)
         os.makedirs(directory, exist_ok=True)
 
-    # Write the content with proper encoding and line endings
-    await write_text_content(file_path, content, encoding, line_endings)
+    # Write the content with UTF-8 encoding and proper line endings
+    await write_text_content(file_path, content, "utf-8", line_endings)
 
     # Commit the changes
     git_message = ""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #168
* __->__ #166
* #165
* #163
* #167
* #164

Get rid of all copies of detect_file_encoding we assume everything is utf-8

```git-revs
9e81779  (Base revision)
1fe96c5  Remove detect_file_encoding function and reference in __all__
c888521  Replace detect_file_encoding with direct utf-8 assumption in apply_edit
b980e44  Use utf-8 encoding directly in edit_file_content
691fd5a  Use utf-8 encoding directly when writing file content
3751db1  Remove detect_file_encoding function from write_file.py
7530378  Use utf-8 encoding directly in write_file_content
cac4e97  Remove unnecessary asyncio import
HEAD     Auto-commit format changes
```

codemcp-id: 178-refactor-remove-detect-file-encoding-and-assume-ut