### PR TITLE
refactor: update run_command.py to accept string instead of list

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -223,7 +223,7 @@ async def codemcp(
             return await run_command(
                 path,
                 command,
-                arguments[0] if isinstance(arguments, list) else arguments,
+                arguments,
                 chat_id,
             )
 

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -95,9 +95,7 @@ async def codemcp(
                 f"Unknown subtool: {subtool}. Available subtools: {', '.join(expected_params.keys())}"
             )
 
-        # Handle string arguments - convert to a list with one element
-        if isinstance(arguments, str):
-            arguments = [arguments]
+        # We no longer need to convert string arguments to list since run_command now only accepts strings
 
         # Normalize string inputs to ensure consistent newlines
         def normalize_newlines(s):
@@ -222,7 +220,12 @@ async def codemcp(
             if command is None:
                 raise ValueError("command is required for RunCommand subtool")
 
-            return await run_command(path, command, arguments, chat_id)
+            return await run_command(
+                path,
+                command,
+                arguments[0] if isinstance(arguments, list) else arguments,
+                chat_id,
+            )
 
         if subtool == "Grep":
             if pattern is None:

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -375,7 +375,7 @@ Example:
 
 Runs a command.  This does NOT support arbitrary code execution, ONLY call
 with this set of valid commands: {command_help}
-When a single string is passed as arguments, it will be interpreted as space-separated
+The arguments parameter should be a string and will be interpreted as space-separated
 arguments using shell-style tokenization (spaces separate arguments, quotes can be used
 for arguments containing spaces, etc.).
 {_generate_command_docs(command_docs)}
@@ -391,7 +391,7 @@ Args:
     offset: Line offset for ReadFile subtool
     limit: Line limit for ReadFile subtool
     description: Short description of the change (for WriteFile/EditFile)
-    arguments: A list of string arguments for RunCommand subtool
+    arguments: A string containing space-separated arguments for RunCommand subtool
     user_prompt: The user's verbatim text (for UserPrompt subtool)
     chat_id: A unique ID to identify the chat session (required for all tools EXCEPT InitProject)
 

--- a/codemcp/tools/run_command.py
+++ b/codemcp/tools/run_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import shlex
-from typing import List, Optional, Union
+from typing import Optional
 
 from .code_command import get_command_from_config, run_code_command
 
@@ -13,7 +13,7 @@ __all__ = [
 async def run_command(
     project_dir: str,
     command: str,
-    arguments: Optional[Union[List[str], str]] = None,
+    arguments: Optional[str] = None,
     chat_id: str = None,
 ) -> str:
     """Run a command that is configured in codemcp.toml.
@@ -21,9 +21,9 @@ async def run_command(
     Args:
         project_dir: The directory path containing the codemcp.toml file
         command: The type of command to run (e.g., "format", "lint", "test")
-        arguments: Optional arguments to pass to the command. If a single string is
-                  provided, it will be parsed into a list of arguments using shell-style
-                  tokenization (spaces separate arguments, quotes can be used for arguments
+        arguments: Optional arguments to pass to the command as a string. It will be
+                  parsed into a list of arguments using shell-style tokenization
+                  (spaces separate arguments, quotes can be used for arguments
                   containing spaces, etc.)
         chat_id: The unique ID of the current chat session
 
@@ -35,13 +35,8 @@ async def run_command(
     # If arguments are provided, extend the command with them
     if arguments and command_list:
         command_list = command_list.copy()
-
-        # If a single string is provided, parse it into a list of arguments
-        if isinstance(arguments, str):
-            parsed_args = shlex.split(arguments)
-            command_list.extend(parsed_args)
-        else:
-            command_list.extend(arguments)
+        parsed_args = shlex.split(arguments)
+        command_list.extend(parsed_args)
 
     return await run_code_command(
         project_dir, command, command_list, f"Auto-commit {command} changes", chat_id

--- a/e2e/test_run_tests.py
+++ b/e2e/test_run_tests.py
@@ -112,7 +112,7 @@ test = ["./run_test.sh"]
                     "subtool": "RunCommand",
                     "path": self.temp_dir.name,
                     "command": "test",
-                    "arguments": ["test_directory/test_another.py"],
+                    "arguments": "test_directory/test_another.py",
                     "chat_id": chat_id,
                 },
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #172
* #171
* #170
* __->__ #168

In codemcp/tools/run_command.py instead of accepting List[str] only ever accept str and assume it is shlex.split'able. Update the prompt for the tool in init_project.py accordingly.

```git-revs
9ac95b0  (Base revision)
ec6dac7  Update run_command to only accept strings for arguments
97a7ab8  Update RunCommand tool description in init_project.py
e54bdf0  Update arguments description in init_project.py
bf1ea0e  Remove string-to-list conversion of arguments in main.py
8c92b9f  Update RunCommand call to handle both string and list arguments (for backward compatibility)
HEAD     Auto-commit format changes
```

codemcp-id: 187-refactor-update-run-command-py-to-accept-string-in