### PR TITLE
feat: implement generic fnmatch-based glob

### DIFF
--- a/codemcp/glob.py
+++ b/codemcp/glob.py
@@ -1,0 +1,254 @@
+"""
+Generic fnmatch-based glob implementation supporting both gitignore and editorconfig glob syntax.
+"""
+
+import fnmatch
+import os
+import re
+from typing import List, Callable, Optional, Tuple, Set
+
+
+def translate_pattern(pattern: str, 
+                      editorconfig_braces: bool = False,
+                      editorconfig_asterisk: bool = False,
+                      editorconfig_double_asterisk: bool = False) -> str:
+    """
+    Translate a glob pattern to a regular expression pattern.
+    
+    Args:
+        pattern: The glob pattern to translate
+        editorconfig_braces: Enable editorconfig brace expansion {s1,s2,s3} and {n1..n2}
+        editorconfig_asterisk: If True, '*' matches any string including path separators
+        editorconfig_double_asterisk: If True, '**' matches any string (editorconfig behavior)
+                                     If False, uses gitignore behavior for '**'
+    
+    Returns:
+        Regular expression pattern string
+    """
+    i, n = 0, len(pattern)
+    result = []
+    
+    # Handle escaped characters
+    escaped = False
+    
+    while i < n:
+        c = pattern[i]
+        i += 1
+        
+        if escaped:
+            # If character was escaped with backslash, add it literally
+            result.append(re.escape(c))
+            escaped = False
+            continue
+            
+        if c == '\\':
+            escaped = True
+            continue
+            
+        elif c == '*':
+            # Check for ** pattern
+            if i < n and pattern[i] == '*':
+                i += 1
+                
+                if editorconfig_double_asterisk:
+                    # EditorConfig: ** matches any string
+                    result.append('.*')
+                else:
+                    # GitIgnore: ** has special meaning in certain positions
+                    
+                    # Case 1: Start of pattern: **/
+                    if i < n and pattern[i] == '/' and result == []:
+                        i += 1
+                        result.append('(?:.*?/)?')
+                        
+                    # Case 2: End of pattern: /**
+                    elif i == n and result and result[-1] == re.escape('/'):
+                        result[-1] = '(?:/.*)?' 
+                        
+                    # Case 3: Middle of pattern: /**/
+                    elif i < n and pattern[i] == '/' and result and result[-1] == re.escape('/'):
+                        i += 1
+                        result.append('(?:.*/)?')
+                        
+                    # Case 4: Other positions: treat as two single asterisks
+                    else:
+                        if editorconfig_asterisk:
+                            result.append('.*')
+                        else:
+                            result.append('[^/]*')
+                        
+                        if editorconfig_asterisk:
+                            result.append('.*')
+                        else:
+                            result.append('[^/]*')
+            else:
+                # Single asterisk
+                if editorconfig_asterisk:
+                    result.append('.*')
+                else:
+                    result.append('[^/]*')
+                    
+        elif c == '?':
+            # ? matches any single character except /
+            result.append('[^/]')
+            
+        elif c == '[':
+            j = i
+            if j < n and pattern[j] == '!':
+                j += 1
+            if j < n and pattern[j] == ']':
+                j += 1
+            while j < n and pattern[j] != ']':
+                j += 1
+            if j >= n:
+                result.append('\\[')
+            else:
+                # Handle character classes
+                stuff = pattern[i:j]
+                if stuff.startswith('!'):
+                    stuff = '^' + stuff[1:]
+                elif stuff.startswith('^'):
+                    stuff = '\\' + stuff
+                i = j + 1
+                
+                if stuff:
+                    result.append('[' + stuff + ']')
+                else:
+                    result.append('\\[\\]')
+                    
+        elif c == '{' and editorconfig_braces:
+            # Handle EditorConfig brace expansion
+            j = i
+            depth = 1
+            while j < n and depth > 0:
+                if pattern[j] == '{':
+                    depth += 1
+                elif pattern[j] == '}':
+                    depth -= 1
+                j += 1
+                
+            if depth > 0:  # No closing brace found
+                result.append('\\{')
+            else:
+                # Extract the brace content
+                brace_content = pattern[i:j-1]
+                i = j
+                
+                # Check if it's a numeric range {num1..num2}
+                num_range_match = re.match(r'^(-?\d+)\.\.(-?\d+)$', brace_content)
+                if num_range_match:
+                    num1 = int(num_range_match.group(1))
+                    num2 = int(num_range_match.group(2))
+                    
+                    # Generate the range alternatives
+                    nums = range(num1, num2 + 1) if num1 <= num2 else range(num1, num2 - 1, -1)
+                    alternatives = '|'.join(str(num) for num in nums)
+                    result.append(f'(?:{alternatives})')
+                else:
+                    # Handle comma-separated items {s1,s2,s3}
+                    # Split but respect any nested braces
+                    items = []
+                    start = 0
+                    nested_depth = 0
+                    
+                    for k, char in enumerate(brace_content):
+                        if char == '{':
+                            nested_depth += 1
+                        elif char == '}':
+                            nested_depth -= 1
+                        elif char == ',' and nested_depth == 0:
+                            items.append(brace_content[start:k])
+                            start = k + 1
+                            
+                    # Add the last item
+                    items.append(brace_content[start:])
+                    
+                    # Convert to regex alternative
+                    alternatives = '|'.join(re.escape(item) for item in items)
+                    result.append(f'(?:{alternatives})')
+                
+        else:
+            result.append(re.escape(c))
+            
+    # Ensure pattern matches the entire string
+    return '^' + ''.join(result) + '$'
+
+
+def make_matcher(pattern: str, **kwargs) -> Callable[[str], bool]:
+    """
+    Create a matcher function that matches paths against the given pattern.
+    
+    Args:
+        pattern: The glob pattern to match against
+        **kwargs: Optional features to enable
+    
+    Returns:
+        A function that takes a path string and returns True if it matches
+    """
+    regex_pattern = translate_pattern(pattern, **kwargs)
+    regex = re.compile(regex_pattern)
+    
+    def matcher(path: str) -> bool:
+        return bool(regex.match(path))
+    
+    return matcher
+
+
+def match(pattern: str, path: str, **kwargs) -> bool:
+    """
+    Test whether a path matches the given pattern.
+    
+    Args:
+        pattern: The glob pattern to match against
+        path: The path to test
+        **kwargs: Optional features to enable
+    
+    Returns:
+        True if the path matches the pattern, False otherwise
+    """
+    matcher = make_matcher(pattern, **kwargs)
+    return matcher(path)
+
+
+def filter(patterns: List[str], paths: List[str], **kwargs) -> List[str]:
+    """
+    Filter a list of paths to those that match any of the given patterns.
+    
+    Args:
+        patterns: List of glob patterns
+        paths: List of paths to filter
+        **kwargs: Optional features to enable
+    
+    Returns:
+        List of paths that match any of the patterns
+    """
+    matchers = [make_matcher(pattern, **kwargs) for pattern in patterns]
+    return [path for path in paths if any(matcher(path) for matcher in matchers)]
+
+
+def find(patterns: List[str], root: str, **kwargs) -> List[str]:
+    """
+    Find all files in the given root directory that match any of the given patterns.
+    
+    Args:
+        patterns: List of glob patterns
+        root: Root directory to search
+        **kwargs: Optional features to enable
+    
+    Returns:
+        List of paths that match any of the patterns
+    """
+    result = []
+    matchers = [make_matcher(pattern, **kwargs) for pattern in patterns]
+    
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dirpath = os.path.relpath(dirpath, root)
+        if rel_dirpath == '.':
+            rel_dirpath = ''
+            
+        for filename in filenames:
+            rel_path = os.path.join(rel_dirpath, filename)
+            if any(matcher(rel_path) for matcher in matchers):
+                result.append(os.path.join(dirpath, filename))
+                
+    return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #176
* #175
* #174
* __->__ #170
* #171

Let's make a generic fnmatch-based glob implementation. We need to support these features. gitignore glob syntax:

* An asterisk "`*`" matches anything except a slash. The character "`?`" matches any one character except "`/`". The range notation, e.g. `[a-zA-Z]`, can be used to match one of the characters in a range. See fnmatch(3) and the FNM_PATHNAME flag for a more detailed description.
Two consecutive asterisks ("`**`") in patterns matched against full pathname may have special meaning:
* A leading "`**`" followed by a slash means match in all directories. For example, "`**/foo`" matches file or directory "`foo`" anywhere, the same as pattern "`foo`". "`**/foo/bar`" matches file or directory "`bar`" anywhere that is directly under directory "`foo`".
* A trailing "`/**`" matches everything inside. For example, "`abc/**`" matches all files inside directory "`abc`", relative to the location of the `.gitignore` file, with infinite depth.
* A slash followed by two consecutive asterisks then a slash matches zero or more directories. For example, "`a/**/b`" matches "`a/b`", "`a/x/b`", "`a/x/y/b`" and so on.
* Other consecutive asterisks are considered regular asterisks and will match according to the previous rules.

And editorconfig glob syntax:

Wildcard Patterns
Special characters recognized in section names for wildcard matching:
`*`Matches any string of characters, except path separators (`/`)`**`Matches any string of characters`?`Matches any single character`[name]`Matches any single character in *name*`[!name]`Matches any single character not in *name*`{s1,s2,s3}`Matches any of the strings given (separated by commas) (**Available since EditorConfig Core 0.11.0**)`{num1..num2}`Matches any integer numbers between *num1* and *num2*, where num1 and num2 can be either positive or negative
Special characters can be escaped with a backslash so they won't be interpreted as wildcard patterns.

As there are some features which are supported by one format but not another, we should take kwargs to enable optional features.  We put the implementation in codemcp/glob.py. Write unit tests.

```git-revs
6846543  (Base revision)
HEAD     Implement generic fnmatch-based glob functionality
```

codemcp-id: 190-feat-implement-generic-fnmatch-based-glob