### PR TITLE
feat: implement generic fnmatch-based glob

### DIFF
--- a/codemcp/glob.py
+++ b/codemcp/glob.py
@@ -2,207 +2,259 @@
 Generic fnmatch-based glob implementation supporting both gitignore and editorconfig glob syntax.
 """
 
-import fnmatch
 import os
 import re
-from typing import List, Callable, Optional, Tuple, Set
+from typing import Callable, List
 
 
-def translate_pattern(pattern: str, 
-                      editorconfig_braces: bool = False,
-                      editorconfig_asterisk: bool = False,
-                      editorconfig_double_asterisk: bool = False) -> str:
+def translate_pattern(
+    pattern: str,
+    editorconfig_braces: bool = False,
+    editorconfig_asterisk: bool = False,
+    editorconfig_double_asterisk: bool = False,
+) -> str:
     """
     Translate a glob pattern to a regular expression pattern.
-    
+
     Args:
         pattern: The glob pattern to translate
         editorconfig_braces: Enable editorconfig brace expansion {s1,s2,s3} and {n1..n2}
         editorconfig_asterisk: If True, '*' matches any string including path separators
         editorconfig_double_asterisk: If True, '**' matches any string (editorconfig behavior)
                                      If False, uses gitignore behavior for '**'
-    
+
     Returns:
         Regular expression pattern string
     """
     i, n = 0, len(pattern)
     result = []
-    
+
     # Handle escaped characters
     escaped = False
-    
+
     while i < n:
         c = pattern[i]
         i += 1
-        
+
         if escaped:
             # If character was escaped with backslash, add it literally
             result.append(re.escape(c))
             escaped = False
             continue
-            
-        if c == '\\':
+
+        if c == "\\":
             escaped = True
             continue
-            
-        elif c == '*':
+
+        elif c == "*":
             # Check for ** pattern
-            if i < n and pattern[i] == '*':
+            if i < n and pattern[i] == "*":
                 i += 1
-                
+
                 if editorconfig_double_asterisk:
                     # EditorConfig: ** matches any string
-                    result.append('.*')
+
+                    # Handle patterns like a/**/b to match across directories
+                    preceding_slash = result and result[-1] == re.escape("/")
+                    following_slash = i < n and pattern[i] == "/"
+
+                    if preceding_slash and following_slash:
+                        # /**/
+                        result.append("(?:.*)")
+                        i += 1  # Skip the slash
+                    elif preceding_slash:
+                        # /**
+                        result.append("(?:.*)")
+                    elif following_slash:
+                        # **/
+                        result.append("(?:.*)")
+                        i += 1  # Skip the slash
+                    else:
+                        # ** in other contexts
+                        result.append("(?:.*)")
                 else:
                     # GitIgnore: ** has special meaning in certain positions
-                    
+
                     # Case 1: Start of pattern: **/
-                    if i < n and pattern[i] == '/' and result == []:
+                    if i < n and pattern[i] == "/" and result == []:
                         i += 1
-                        result.append('(?:.*?/)?')
-                        
+                        result.append("(?:.*?/)?")
+
                     # Case 2: End of pattern: /**
-                    elif i == n and result and result[-1] == re.escape('/'):
-                        result[-1] = '(?:/.*)?' 
-                        
+                    elif i == n and result and result[-1] == re.escape("/"):
+                        result[-1] = "(?:/.*)?"
+
                     # Case 3: Middle of pattern: /**/
-                    elif i < n and pattern[i] == '/' and result and result[-1] == re.escape('/'):
+                    elif (
+                        i < n
+                        and pattern[i] == "/"
+                        and result
+                        and result[-1] == re.escape("/")
+                    ):
                         i += 1
-                        result.append('(?:.*/)?')
-                        
+                        result.append("(?:.*/)?")
+
                     # Case 4: Other positions: treat as two single asterisks
                     else:
                         if editorconfig_asterisk:
-                            result.append('.*')
+                            result.append(".*")
                         else:
-                            result.append('[^/]*')
-                        
+                            result.append("[^/]*")
+
                         if editorconfig_asterisk:
-                            result.append('.*')
+                            result.append(".*")
                         else:
-                            result.append('[^/]*')
+                            result.append("[^/]*")
             else:
                 # Single asterisk
                 if editorconfig_asterisk:
-                    result.append('.*')
+                    result.append(".*")
                 else:
-                    result.append('[^/]*')
-                    
-        elif c == '?':
+                    result.append("[^/]*")
+
+        elif c == "?":
             # ? matches any single character except /
-            result.append('[^/]')
-            
-        elif c == '[':
+            result.append("[^/]")
+
+        elif c == "[":
             j = i
-            if j < n and pattern[j] == '!':
+            if j < n and pattern[j] == "!":
                 j += 1
-            if j < n and pattern[j] == ']':
+            if j < n and pattern[j] == "]":
                 j += 1
-            while j < n and pattern[j] != ']':
+            while j < n and pattern[j] != "]":
                 j += 1
             if j >= n:
-                result.append('\\[')
+                result.append("\\[")
             else:
                 # Handle character classes
                 stuff = pattern[i:j]
-                if stuff.startswith('!'):
-                    stuff = '^' + stuff[1:]
-                elif stuff.startswith('^'):
-                    stuff = '\\' + stuff
+                if stuff.startswith("!"):
+                    stuff = "^" + stuff[1:]
+                elif stuff.startswith("^"):
+                    stuff = "\\" + stuff
                 i = j + 1
-                
+
                 if stuff:
-                    result.append('[' + stuff + ']')
+                    result.append("[" + stuff + "]")
                 else:
-                    result.append('\\[\\]')
-                    
-        elif c == '{' and editorconfig_braces:
+                    result.append("\\[\\]")
+
+        elif c == "{" and editorconfig_braces:
             # Handle EditorConfig brace expansion
             j = i
             depth = 1
             while j < n and depth > 0:
-                if pattern[j] == '{':
+                if pattern[j] == "{":
                     depth += 1
-                elif pattern[j] == '}':
+                elif pattern[j] == "}":
                     depth -= 1
                 j += 1
-                
-            if depth > 0:  # No closing brace found
-                result.append('\\{')
+
+            if depth > 0 or j == i:  # No closing brace found or empty braces
+                result.append("\\{")
             else:
                 # Extract the brace content
-                brace_content = pattern[i:j-1]
+                brace_content = pattern[i : j - 1]
                 i = j
-                
+
                 # Check if it's a numeric range {num1..num2}
-                num_range_match = re.match(r'^(-?\d+)\.\.(-?\d+)$', brace_content)
+                num_range_match = re.match(r"^(-?\d+)\.\.(-?\d+)$", brace_content)
                 if num_range_match:
                     num1 = int(num_range_match.group(1))
                     num2 = int(num_range_match.group(2))
-                    
+
                     # Generate the range alternatives
-                    nums = range(num1, num2 + 1) if num1 <= num2 else range(num1, num2 - 1, -1)
-                    alternatives = '|'.join(str(num) for num in nums)
-                    result.append(f'(?:{alternatives})')
+                    nums = (
+                        range(num1, num2 + 1)
+                        if num1 <= num2
+                        else range(num1, num2 - 1, -1)
+                    )
+                    alternatives = "|".join(str(num) for num in nums)
+                    result.append(f"(?:{alternatives})")
                 else:
                     # Handle comma-separated items {s1,s2,s3}
                     # Split but respect any nested braces
                     items = []
                     start = 0
                     nested_depth = 0
-                    
+
                     for k, char in enumerate(brace_content):
-                        if char == '{':
+                        if char == "{":
                             nested_depth += 1
-                        elif char == '}':
+                        elif char == "}":
                             nested_depth -= 1
-                        elif char == ',' and nested_depth == 0:
+                        elif char == "," and nested_depth == 0:
                             items.append(brace_content[start:k])
                             start = k + 1
-                            
+
                     # Add the last item
                     items.append(brace_content[start:])
-                    
-                    # Convert to regex alternative
-                    alternatives = '|'.join(re.escape(item) for item in items)
-                    result.append(f'(?:{alternatives})')
-                
+
+                    if not items or all(not item for item in items):
+                        result.append("\\{")
+                        # Roll back the index to continue processing after the opening brace
+                        i = i - len(brace_content) - 2
+                    else:
+                        # Process each item recursively to handle nested braces
+                        processed_items = []
+                        for item in items:
+                            # For nested patterns, recursively translate but without the anchors
+                            if "{" in item:
+                                item_pattern = translate_pattern(
+                                    item,
+                                    editorconfig_braces=True,
+                                    editorconfig_asterisk=editorconfig_asterisk,
+                                    editorconfig_double_asterisk=editorconfig_double_asterisk,
+                                )
+                                # Remove the anchors (^ and $)
+                                if item_pattern.startswith("^"):
+                                    item_pattern = item_pattern[1:]
+                                if item_pattern.endswith("$"):
+                                    item_pattern = item_pattern[:-1]
+                                processed_items.append(item_pattern)
+                            else:
+                                processed_items.append(re.escape(item))
+
+                        alternatives = "|".join(processed_items)
+                        result.append(f"(?:{alternatives})")
+
         else:
             result.append(re.escape(c))
-            
+
     # Ensure pattern matches the entire string
-    return '^' + ''.join(result) + '$'
+    return "^" + "".join(result) + "$"
 
 
 def make_matcher(pattern: str, **kwargs) -> Callable[[str], bool]:
     """
     Create a matcher function that matches paths against the given pattern.
-    
+
     Args:
         pattern: The glob pattern to match against
         **kwargs: Optional features to enable
-    
+
     Returns:
         A function that takes a path string and returns True if it matches
     """
     regex_pattern = translate_pattern(pattern, **kwargs)
     regex = re.compile(regex_pattern)
-    
+
     def matcher(path: str) -> bool:
         return bool(regex.match(path))
-    
+
     return matcher
 
 
 def match(pattern: str, path: str, **kwargs) -> bool:
     """
     Test whether a path matches the given pattern.
-    
+
     Args:
         pattern: The glob pattern to match against
         path: The path to test
         **kwargs: Optional features to enable
-    
+
     Returns:
         True if the path matches the pattern, False otherwise
     """
@@ -213,12 +265,12 @@ def match(pattern: str, path: str, **kwargs) -> bool:
 def filter(patterns: List[str], paths: List[str], **kwargs) -> List[str]:
     """
     Filter a list of paths to those that match any of the given patterns.
-    
+
     Args:
         patterns: List of glob patterns
         paths: List of paths to filter
         **kwargs: Optional features to enable
-    
+
     Returns:
         List of paths that match any of the patterns
     """
@@ -229,26 +281,26 @@ def filter(patterns: List[str], paths: List[str], **kwargs) -> List[str]:
 def find(patterns: List[str], root: str, **kwargs) -> List[str]:
     """
     Find all files in the given root directory that match any of the given patterns.
-    
+
     Args:
         patterns: List of glob patterns
         root: Root directory to search
         **kwargs: Optional features to enable
-    
+
     Returns:
         List of paths that match any of the patterns
     """
     result = []
     matchers = [make_matcher(pattern, **kwargs) for pattern in patterns]
-    
+
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dirpath = os.path.relpath(dirpath, root)
-        if rel_dirpath == '.':
-            rel_dirpath = ''
-            
+        if rel_dirpath == ".":
+            rel_dirpath = ""
+
         for filename in filenames:
             rel_path = os.path.join(rel_dirpath, filename)
             if any(matcher(rel_path) for matcher in matchers):
                 result.append(os.path.join(dirpath, filename))
-                
+
     return result

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1,0 +1,286 @@
+"""
+Test for the glob module's pattern matching functionality.
+"""
+
+import os
+import shutil
+import tempfile
+
+from codemcp import glob
+
+
+def setup_test_directory():
+    """Create a temporary directory with files for testing."""
+    test_dir = tempfile.mkdtemp()
+
+    # Create a nested directory structure with files
+    dirs = [
+        "",
+        "a",
+        "a/b",
+        "a/b/c",
+        "a/d",
+        "a/d/e",
+        "x",
+        "x/y",
+        "x/y/z",
+    ]
+
+    files = [
+        "file1.txt",
+        "file2.py",
+        "a/file.txt",
+        "a/file.py",
+        "a/b/file.txt",
+        "a/b/file.py",
+        "a/b/c/deep.txt",
+        "a/d/file.txt",
+        "a/d/e/deep.py",
+        "x/file.txt",
+        "x/y/file.py",
+        "x/y/z/deep.txt",
+    ]
+
+    # Create directories
+    for d in dirs:
+        dir_path = os.path.join(test_dir, d)
+        if d:  # Skip empty string (root directory)
+            os.makedirs(dir_path, exist_ok=True)
+
+    # Create files
+    for f in files:
+        file_path = os.path.join(test_dir, f)
+        with open(file_path, "w") as fh:
+            fh.write(f"Test content for {f}")
+
+    return test_dir
+
+
+def teardown_test_directory(test_dir):
+    """Remove the temporary test directory."""
+    shutil.rmtree(test_dir)
+
+
+def test_gitignore_simple_asterisk():
+    """Test simple * pattern with gitignore behavior."""
+    # * should match anything except slash
+    assert glob.match("*.txt", "file1.txt")
+    assert glob.match("*.txt", "a.txt")
+    assert not glob.match("*.txt", "dir/file.txt")
+    assert not glob.match("*.txt", "file.py")
+
+
+def test_gitignore_question_mark():
+    """Test ? pattern with gitignore behavior."""
+    # ? should match any single character except slash
+    assert glob.match("file?.txt", "file1.txt")
+    assert glob.match("file?.txt", "fileA.txt")
+    assert not glob.match("file?.txt", "file12.txt")
+    assert not glob.match("file?.txt", "file.txt")
+    assert not glob.match("file?.txt", "dir/file1.txt")
+
+
+def test_gitignore_character_class():
+    """Test character class patterns with gitignore behavior."""
+    # [abc] should match any character in the brackets
+    assert glob.match("file[123].txt", "file1.txt")
+    assert glob.match("file[123].txt", "file2.txt")
+    assert not glob.match("file[123].txt", "file4.txt")
+
+    # [!abc] should match any character not in the brackets
+    assert glob.match("file[!123].txt", "file4.txt")
+    assert glob.match("file[!123].txt", "fileA.txt")
+    assert not glob.match("file[!123].txt", "file1.txt")
+
+    # [a-z] should match any character in the range
+    assert glob.match("file[a-z].txt", "filea.txt")
+    assert glob.match("file[a-z].txt", "filez.txt")
+    assert not glob.match("file[a-z].txt", "file1.txt")
+    assert not glob.match("file[a-z].txt", "fileA.txt")
+
+
+def test_gitignore_leading_double_asterisk():
+    """Test leading **/ pattern with gitignore behavior."""
+    # **/ should match in all directories
+    assert glob.match("**/file.txt", "file.txt")
+    assert glob.match("**/file.txt", "a/file.txt")
+    assert glob.match("**/file.txt", "a/b/file.txt")
+    assert not glob.match("**/file.txt", "file1.txt")
+    assert not glob.match("**/file.txt", "a/file1.txt")
+
+    # **/foo/bar should match bar anywhere directly under foo
+    assert glob.match("**/a/file.txt", "a/file.txt")
+    assert glob.match("**/a/file.txt", "x/a/file.txt")
+    assert not glob.match("**/a/file.txt", "a/b/file.txt")
+
+
+def test_gitignore_trailing_double_asterisk():
+    """Test trailing /** pattern with gitignore behavior."""
+    # /** should match everything inside
+    assert glob.match("a/**", "a/file.txt")
+    assert glob.match("a/**", "a/b/file.txt")
+    assert glob.match("a/**", "a/b/c/deep.txt")
+    assert not glob.match("a/**", "file.txt")
+    assert not glob.match("a/**", "x/file.txt")
+
+
+def test_gitignore_middle_double_asterisk():
+    """Test /**/pattern with gitignore behavior."""
+    # /**/ should match zero or more directories
+    assert glob.match("a/**/file.txt", "a/file.txt")
+    assert glob.match("a/**/file.txt", "a/b/file.txt")
+    assert glob.match("a/**/file.txt", "a/b/c/file.txt")
+    assert not glob.match("a/**/file.txt", "file.txt")
+    assert not glob.match("a/**/file.txt", "a/file.py")
+
+
+def test_editorconfig_braces():
+    """Test editorconfig brace expansion."""
+    # {s1,s2,s3} should match any of the strings
+    assert glob.match("file.{txt,py}", "file.txt", editorconfig_braces=True)
+    assert glob.match("file.{txt,py}", "file.py", editorconfig_braces=True)
+    assert not glob.match("file.{txt,py}", "file.md", editorconfig_braces=True)
+
+    # {num1..num2} should match any integer in the range
+    assert glob.match("file{1..3}.txt", "file1.txt", editorconfig_braces=True)
+    assert glob.match("file{1..3}.txt", "file2.txt", editorconfig_braces=True)
+    assert glob.match("file{1..3}.txt", "file3.txt", editorconfig_braces=True)
+    assert not glob.match("file{1..3}.txt", "file4.txt", editorconfig_braces=True)
+    assert not glob.match("file{1..3}.txt", "file0.txt", editorconfig_braces=True)
+
+    # Negative ranges
+    assert glob.match("file{-1..1}.txt", "file-1.txt", editorconfig_braces=True)
+    assert glob.match("file{-1..1}.txt", "file0.txt", editorconfig_braces=True)
+    assert glob.match("file{-1..1}.txt", "file1.txt", editorconfig_braces=True)
+
+    # Braces can be nested
+    assert glob.match("file{a,{b,c}}.txt", "filea.txt", editorconfig_braces=True)
+    assert glob.match("file{a,{b,c}}.txt", "fileb.txt", editorconfig_braces=True)
+    assert glob.match("file{a,{b,c}}.txt", "filec.txt", editorconfig_braces=True)
+
+
+def test_editorconfig_asterisk():
+    """Test editorconfig asterisk behavior."""
+    # * should match any string including path separators
+    assert glob.match("*.txt", "file.txt", editorconfig_asterisk=True)
+    assert glob.match("*.txt", "dir/file.txt", editorconfig_asterisk=True)
+    assert not glob.match("*.txt", "file.py", editorconfig_asterisk=True)
+
+
+def test_editorconfig_double_asterisk():
+    """Test editorconfig ** behavior."""
+    # ** should match any string
+    assert glob.match("**", "file.txt", editorconfig_double_asterisk=True)
+    assert glob.match("**", "dir/file.txt", editorconfig_double_asterisk=True)
+    assert glob.match("**", "dir/subdir/file.txt", editorconfig_double_asterisk=True)
+
+    # More specific pattern with **
+    assert glob.match("a/**/file.txt", "a/file.txt", editorconfig_double_asterisk=True)
+    assert glob.match(
+        "a/**/file.txt", "a/b/file.txt", editorconfig_double_asterisk=True
+    )
+    assert glob.match(
+        "a/**/file.txt", "a/b/c/file.txt", editorconfig_double_asterisk=True
+    )
+
+
+def test_escaped_characters():
+    """Test escaped special characters in patterns."""
+    # Escaped special characters should be treated as literals
+    assert glob.match(r"\*.txt", "*.txt")
+    assert not glob.match(r"\*.txt", "a.txt")
+
+    assert glob.match(r"\?.txt", "?.txt")
+    assert not glob.match(r"\?.txt", "a.txt")
+
+    assert glob.match(r"\[abc\].txt", "[abc].txt")
+    assert not glob.match(r"\[abc\].txt", "a.txt")
+
+
+def test_combined_features():
+    """Test combining different pattern features."""
+    # Combining various features
+    assert glob.match(
+        "**/[a-z]/{file,test}.{txt,py}", "a/file.txt", editorconfig_braces=True
+    )
+    assert glob.match(
+        "**/[a-z]/{file,test}.{txt,py}", "x/y/z/test.py", editorconfig_braces=True
+    )
+    assert not glob.match(
+        "**/[a-z]/{file,test}.{txt,py}", "1/file.txt", editorconfig_braces=True
+    )
+    assert not glob.match(
+        "**/[a-z]/{file,test}.{txt,py}", "a/other.txt", editorconfig_braces=True
+    )
+
+
+def test_filter_function():
+    """Test the filter function."""
+    paths = [
+        "file1.txt",
+        "file2.py",
+        "dir/file.txt",
+        "dir/file.py",
+        "dir/subdir/file.txt",
+    ]
+
+    # Filter with a single pattern
+    result = glob.filter(["*.txt"], paths)
+    assert result == ["file1.txt"]
+
+    # Filter with multiple patterns
+    result = glob.filter(["*.txt", "*.py"], paths)
+    assert result == ["file1.txt", "file2.py"]
+
+    # Filter with gitignore-specific pattern
+    result = glob.filter(["**/file.txt"], paths)
+    assert result == ["dir/file.txt", "dir/subdir/file.txt"]
+
+
+def test_find_function():
+    """Test the find function with a temporary directory."""
+    test_dir = setup_test_directory()
+
+    try:
+        # Find with a simple pattern
+        result = glob.find(["*.txt"], test_dir)
+        assert len(result) == 1
+        assert os.path.basename(result[0]) == "file1.txt"
+
+        # Find with gitignore-specific pattern
+        result = glob.find(["**/file.txt"], test_dir)
+        filenames = [os.path.basename(path) for path in result]
+        assert all(filename == "file.txt" for filename in filenames)
+        # There are 4 file.txt files in our test directory structure:
+        # a/file.txt, a/b/file.txt, a/d/file.txt, x/file.txt
+        assert len(result) == 4
+
+        # Find with combination of patterns
+        result = glob.find(["a/**/*.py"], test_dir)
+        assert len(result) == 3
+        assert any("a/file.py" in path for path in result)
+        assert any("a/b/file.py" in path for path in result)
+        assert any("a/d/e/deep.py" in path for path in result)
+
+    finally:
+        teardown_test_directory(test_dir)
+
+
+def test_make_matcher_function():
+    """Test the make_matcher function."""
+    # Create a matcher function
+    matcher = glob.make_matcher("*.txt")
+
+    # Test the matcher
+    assert matcher("file.txt")
+    assert not matcher("file.py")
+    assert not matcher("dir/file.txt")
+
+    # Create a matcher with gitignore-specific behavior
+    matcher = glob.make_matcher("**/file.txt")
+
+    # Test the matcher
+    assert matcher("file.txt")
+    assert matcher("dir/file.txt")
+    assert matcher("dir/subdir/file.txt")
+    assert not matcher("file.py")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Let's make a generic fnmatch-based glob implementation. We need to support these features. gitignore glob syntax:

* An asterisk "`*`" matches anything except a slash. The character "`?`" matches any one character except "`/`". The range notation, e.g. `[a-zA-Z]`, can be used to match one of the characters in a range. See fnmatch(3) and the FNM_PATHNAME flag for a more detailed description.
Two consecutive asterisks ("`**`") in patterns matched against full pathname may have special meaning:
* A leading "`**`" followed by a slash means match in all directories. For example, "`**/foo`" matches file or directory "`foo`" anywhere, the same as pattern "`foo`". "`**/foo/bar`" matches file or directory "`bar`" anywhere that is directly under directory "`foo`".
* A trailing "`/**`" matches everything inside. For example, "`abc/**`" matches all files inside directory "`abc`", relative to the location of the `.gitignore` file, with infinite depth.
* A slash followed by two consecutive asterisks then a slash matches zero or more directories. For example, "`a/**/b`" matches "`a/b`", "`a/x/b`", "`a/x/y/b`" and so on.
* Other consecutive asterisks are considered regular asterisks and will match according to the previous rules.

And editorconfig glob syntax:

Wildcard Patterns
Special characters recognized in section names for wildcard matching:
`*`Matches any string of characters, except path separators (`/`)`**`Matches any string of characters`?`Matches any single character`[name]`Matches any single character in *name*`[!name]`Matches any single character not in *name*`{s1,s2,s3}`Matches any of the strings given (separated by commas) (**Available since EditorConfig Core 0.11.0**)`{num1..num2}`Matches any integer numbers between *num1* and *num2*, where num1 and num2 can be either positive or negative
Special characters can be escaped with a backslash so they won't be interpreted as wildcard patterns.

As there are some features which are supported by one format but not another, we should take kwargs to enable optional features.  We put the implementation in codemcp/glob.py. Write unit tests.

```git-revs
cb69583  (Base revision)
e7e8323  Create glob unit tests in tests directory
cb9d04b  Fix implementation of brace expansion in glob pattern translation
009013a  Fix editorconfig double asterisk handling to properly match patterns like a/**/b
51a2859  Fix test_find_function to expect 4 file.txt files
2f0b56b  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 190-feat-implement-generic-fnmatch-based-glob