### PR TITLE
refactor: move non-tool items from tools directory to root

### DIFF
--- a/codemcp/access.py
+++ b/codemcp/access.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import subprocess
 
 from .git_query import get_repository_root
 

--- a/codemcp/async_file_utils.py
+++ b/codemcp/async_file_utils.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+import os
+from typing import List
+
+import anyio
+
+from .line_endings import detect_line_endings
+
+
+async def async_open_text(
+    file_path: str,
+    mode: str = "r",
+    encoding: str = "utf-8",
+    errors: str = "replace",
+) -> str:
+    """Asynchronously open and read a text file.
+
+    Args:
+        file_path: The path to the file
+        mode: The file open mode (default: 'r')
+        encoding: The text encoding (default: 'utf-8')
+        errors: How to handle encoding errors (default: 'replace')
+
+    Returns:
+        The file content as a string
+    """
+    async with await anyio.open_file(
+        file_path, mode, encoding=encoding, errors=errors
+    ) as f:
+        return await f.read()
+
+
+async def async_open_binary(file_path: str, mode: str = "rb") -> bytes:
+    """Asynchronously open and read a binary file.
+
+    Args:
+        file_path: The path to the file
+        mode: The file open mode (default: 'rb')
+
+    Returns:
+        The file content as bytes
+    """
+    async with await anyio.open_file(file_path, mode) as f:
+        return await f.read()
+
+
+async def async_readlines(
+    file_path: str, encoding: str = "utf-8", errors: str = "replace"
+) -> List[str]:
+    """Asynchronously read lines from a text file.
+
+    Args:
+        file_path: The path to the file
+        encoding: The text encoding (default: 'utf-8')
+        errors: How to handle encoding errors (default: 'replace')
+
+    Returns:
+        A list of lines from the file
+    """
+    async with await anyio.open_file(
+        file_path, "r", encoding=encoding, errors=errors
+    ) as f:
+        return await f.readlines()
+
+
+async def async_write_text(
+    file_path: str,
+    content: str,
+    mode: str = "w",
+    encoding: str = "utf-8",
+) -> None:
+    """Asynchronously write text to a file.
+
+    Args:
+        file_path: The path to the file
+        content: The text content to write
+        mode: The file open mode (default: 'w')
+        encoding: The text encoding (default: 'utf-8')
+    """
+    async with await anyio.open_file(file_path, mode, encoding=encoding) as f:
+        await f.write(content)
+
+
+async def async_write_binary(file_path: str, content: bytes, mode: str = "wb") -> None:
+    """Asynchronously write binary data to a file.
+
+    Args:
+        file_path: The path to the file
+        content: The binary content to write
+        mode: The file open mode (default: 'wb')
+    """
+    async with await anyio.open_file(file_path, mode) as f:
+        await f.write(content)
+
+
+async def async_detect_encoding(file_path: str) -> str:
+    """Asynchronously detect the encoding of a file.
+
+    Args:
+        file_path: The path to the file
+
+    Returns:
+        The detected encoding, defaulting to 'utf-8'
+    """
+    if not os.path.exists(file_path):
+        return "utf-8"
+
+    try:
+        # Try to read with utf-8 first
+        await async_open_text(file_path, encoding="utf-8")
+        return "utf-8"
+    except UnicodeDecodeError:
+        # If utf-8 fails, default to a more permissive encoding
+        return "latin-1"
+
+
+async def async_detect_line_endings(file_path: str) -> str:
+    """Asynchronously detect the line endings of a file.
+
+    Args:
+        file_path: The path to the file
+
+    Returns:
+        'CRLF' or 'LF'
+    """
+    return await detect_line_endings(file_path, return_format="format")

--- a/codemcp/file_utils.py
+++ b/codemcp/file_utils.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+import asyncio
+import logging
+import os
+
+import anyio
+
+from .access import check_edit_permission
+from .git import commit_changes
+from .line_endings import apply_line_endings, normalize_to_lf
+
+__all__ = [
+    "check_file_path_and_permissions",
+    "check_git_tracking_for_existing_file",
+    "ensure_directory_exists",
+    "write_text_content",
+    "async_open_text",
+]
+
+
+async def check_file_path_and_permissions(file_path: str) -> tuple[bool, str | None]:
+    """Check if the file path is valid and has the necessary permissions.
+
+    Args:
+        file_path: The absolute path to the file
+
+    Returns:
+        A tuple of (is_valid, error_message)
+        If is_valid is True, error_message will be None
+
+    """
+    # Check that the path is absolute
+    if not os.path.isabs(file_path):
+        return False, f"File path must be absolute, not relative: {file_path}"
+
+    # Check if we have permission to edit this file
+    is_permitted, permission_message = await check_edit_permission(file_path)
+    if not is_permitted:
+        return False, permission_message
+
+    return True, None
+
+
+async def check_git_tracking_for_existing_file(
+    file_path: str,
+    chat_id: str,
+) -> tuple[bool, str | None]:
+    """Check if an existing file is tracked by git. Skips check for non-existent files.
+
+    Args:
+        file_path: The absolute path to the file
+        chat_id: The unique ID to identify the chat session
+
+    Returns:
+        A tuple of (success, error_message)
+        If success is True, error_message will be None
+
+    """
+    # Check if the file exists
+    file_exists = os.path.exists(file_path)
+
+    if file_exists:
+        # Check if the file is tracked by git - use ls-files directly since we just need to check tracking
+        directory = os.path.dirname(file_path)
+
+        # Check if the file is tracked by git
+        from .shell import run_command
+
+        file_status = await run_command(
+            ["git", "ls-files", "--error-unmatch", file_path],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        file_is_tracked = file_status.returncode == 0
+
+        # If the file is not tracked, return an error
+        if not file_is_tracked:
+            error_msg = "File is not tracked by git. Please add the file to git tracking first using 'git add <file>'"
+            return False, error_msg
+
+        # If there are other uncommitted changes, commit them
+        commit_success, commit_message = await commit_changes(
+            file_path,
+            description="Snapshot before codemcp change",
+            chat_id=chat_id,
+        )
+
+        if not commit_success:
+            logging.debug(f"Failed to commit pending changes: {commit_message}")
+        else:
+            logging.debug(f"Pending changes status: {commit_message}")
+
+    return True, None
+
+
+def ensure_directory_exists(file_path: str) -> None:
+    """Ensure the directory for the file exists, creating it if necessary.
+
+    Args:
+        file_path: The absolute path to the file
+
+    """
+    directory = os.path.dirname(file_path)
+    if not os.path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
+
+
+async def async_open_text(
+    file_path: str,
+    mode: str = "r",
+    encoding: str = "utf-8",
+    errors: str = "replace",
+) -> str:
+    """Asynchronously open and read a text file.
+
+    Args:
+        file_path: The path to the file
+        mode: The file open mode (default: 'r')
+        encoding: The text encoding (default: 'utf-8')
+        errors: How to handle encoding errors (default: 'replace')
+
+    Returns:
+        The file content as a string
+    """
+    async with await anyio.open_file(
+        file_path, mode, encoding=encoding, errors=errors
+    ) as f:
+        return await f.read()
+
+
+async def write_text_content(
+    file_path: str,
+    content: str,
+    encoding: str = "utf-8",
+    line_endings: str | None = None,
+) -> None:
+    """Write text content to a file with specified encoding and line endings.
+
+    Args:
+        file_path: The path to the file
+        content: The content to write
+        encoding: The encoding to use
+        line_endings: The line endings to use ('CRLF', 'LF', '\r\n', or '\n').
+                     If None, uses the system default.
+    """
+    # First normalize content to LF line endings
+    normalized_content = normalize_to_lf(content)
+
+    # Apply the requested line ending
+    final_content = apply_line_endings(normalized_content, line_endings)
+
+    # Ensure directory exists
+    ensure_directory_exists(file_path)
+
+    # Write the content asynchronously using run_in_executor
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(
+        None, lambda: write_file_sync(file_path, final_content, encoding)
+    )
+
+
+def write_file_sync(file_path: str, content: str, encoding: str = "utf-8") -> None:
+    """Synchronous helper function to write file content.
+
+    Args:
+        file_path: The path to the file
+        content: The content to write
+        encoding: The encoding to use
+    """
+    with open(file_path, "w", encoding=encoding) as f:
+        f.write(content)

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -9,6 +9,7 @@ import unittest
 from contextlib import asynccontextmanager
 from typing import Any, List, Union
 from unittest import mock
+
 from expecttest import TestCase
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client

--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -9,14 +9,14 @@ import re
 from difflib import SequenceMatcher
 
 from ..common import get_edit_snippet
-from ..git import commit_changes
-from ..line_endings import detect_line_endings
-from .file_utils import (
+from ..file_utils import (
     async_open_text,
     check_file_path_and_permissions,
     check_git_tracking_for_existing_file,
     write_text_content,
 )
+from ..git import commit_changes
+from ..line_endings import detect_line_endings
 
 # Set up logger
 logger = logging.getLogger(__name__)

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -53,7 +53,7 @@ async def read_file_content(
         )
 
     # Handle text files - use async file operations with anyio
-    from .async_file_utils import async_readlines
+    from ..async_file_utils import async_readlines
 
     all_lines = await async_readlines(
         full_file_path, encoding="utf-8", errors="replace"

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -2,13 +2,13 @@
 
 import os
 
-from ..git import commit_changes
-from ..line_endings import detect_line_endings, detect_repo_line_endings
-from .file_utils import (
+from ..file_utils import (
     check_file_path_and_permissions,
     check_git_tracking_for_existing_file,
     write_text_content,
 )
+from ..git import commit_changes
+from ..line_endings import detect_line_endings, detect_repo_line_endings
 
 __all__ = [
     "write_file_content",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

There are some things in codemcp/tools/ that are not tools. They should go in codemcp/ instead.

```git-revs
9ce4cf1  (Base revision)
be06eb0  Move file_utils.py from tools directory to root directory
bbfc104  Move async_file_utils.py from tools directory to root directory
643e747  Update import path for async_file_utils in read_file.py
2aa7fae  Update import path for file_utils in write_file.py
cb578bf  Update import path for file_utils in edit_file.py
ed1c732  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 199-refactor-move-non-tool-items-from-tools-directory-