### PR TITLE
refactor: port write_file_sync to anyio

### DIFF
--- a/codemcp/access.py
+++ b/codemcp/access.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import subprocess
 
 from .git_query import get_repository_root
 

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -9,6 +9,7 @@ import unittest
 from contextlib import asynccontextmanager
 from typing import Any, List, Union
 from unittest import mock
+
 from expecttest import TestCase
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client

--- a/codemcp/tools/async_file_utils.py
+++ b/codemcp/tools/async_file_utils.py
@@ -78,7 +78,9 @@ async def async_write_text(
         mode: The file open mode (default: 'w')
         encoding: The text encoding (default: 'utf-8')
     """
-    async with await anyio.open_file(file_path, mode, encoding=encoding, newline='') as f:
+    async with await anyio.open_file(
+        file_path, mode, encoding=encoding, newline=""
+    ) as f:
         await f.write(content)
 
 
@@ -90,7 +92,7 @@ async def async_write_binary(file_path: str, content: bytes, mode: str = "wb") -
         content: The binary content to write
         mode: The file open mode (default: 'wb')
     """
-    async with await anyio.open_file(file_path, mode, newline='') as f:
+    async with await anyio.open_file(file_path, mode, newline="") as f:
         await f.write(content)
 
 

--- a/codemcp/tools/file_utils.py
+++ b/codemcp/tools/file_utils.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import asyncio
 import logging
 import os
 
@@ -156,20 +155,8 @@ async def write_text_content(
     # Ensure directory exists
     ensure_directory_exists(file_path)
 
-    # Write the content asynchronously using run_in_executor
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(
-        None, lambda: write_file_sync(file_path, final_content, encoding)
-    )
-
-
-def write_file_sync(file_path: str, content: str, encoding: str = "utf-8") -> None:
-    """Synchronous helper function to write file content.
-
-    Args:
-        file_path: The path to the file
-        content: The content to write
-        encoding: The encoding to use
-    """
-    with open(file_path, "w", encoding=encoding, newline='') as f:
-        f.write(content)
+    # Write the content using anyio
+    async with await anyio.open_file(
+        file_path, "w", encoding=encoding, newline=""
+    ) as f:
+        await f.write(final_content)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #187

write_file_sync and calls to it with run_in_executor are now unnecessary as we took on an anyio dependency. Port all calls to this to anyio and then delete this function.

```git-revs
983ccfb  (Base revision)
21e1eaf  Replace write_file_sync with anyio implementation in write_text_content
4506980  Remove unused asyncio import
e715fff  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 200-refactor-port-write-file-sync-to-anyio