### PR TITLE
feat: add think tool for complex reasoning

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -12,6 +12,7 @@ from .tools.init_project import init_project
 from .tools.ls import ls_directory
 from .tools.read_file import read_file_content
 from .tools.run_command import run_command
+from .tools.think import think
 from .tools.user_prompt import user_prompt as user_prompt_tool
 from .tools.write_file import write_file_content
 
@@ -42,6 +43,7 @@ async def codemcp(
     subject_line: str | None = None,  # Added for InitProject commit message
     reuse_head_chat_id: bool
     | None = None,  # Whether to reuse the chat ID from the HEAD commit
+    thought: str | None = None,  # Added for Think tool
 ) -> str:
     """If and only if the user explicitly asks you to initialize codemcp with
     path, you should invoke this tool.  This will return instructions which you should
@@ -54,12 +56,13 @@ async def codemcp(
     with the user's verbatim message text.
 
     Arguments:
-      subtool: The subtool to run (InitProject, UserPrompt, ...)
+      subtool: The subtool to run (InitProject, UserPrompt, Think, ...)
       path: The path to the file or directory to operate on
       chat_id: A unique ID to identify the chat session (provided by InitProject and required for all tools EXCEPT InitProject)
       user_prompt: The user's original prompt verbatim, starting AFTER instructions to initialize codemcp (e.g., you should exclude "Initialize codemcp for PATH")
       subject_line: A short subject line in Git conventional commit format (for InitProject)
       reuse_head_chat_id: If True, reuse the chat ID from the HEAD commit instead of generating a new one (for InitProject)
+      thought: The thought content for the Think tool (used for complex reasoning or cache memory)
       ... (there are other arguments which are documented later)
     """
     try:
@@ -87,6 +90,7 @@ async def codemcp(
             "RunCommand": {"path", "command", "arguments", "chat_id"},
             "Grep": {"pattern", "path", "include", "chat_id"},
             "Glob": {"pattern", "path", "limit", "offset", "chat_id"},
+            "Think": {"thought", "chat_id"},
         }
 
         # Check if subtool exists
@@ -137,6 +141,8 @@ async def codemcp(
                 "subject_line": subject_line,
                 # Whether to reuse the chat ID from the HEAD commit
                 "reuse_head_chat_id": reuse_head_chat_id,
+                # Think tool parameter
+                "thought": thought,
             }.items()
             if value is not None
         }
@@ -274,6 +280,12 @@ async def codemcp(
                 raise ValueError("user_prompt is required for UserPrompt subtool")
 
             return await user_prompt_tool(user_prompt, chat_id)
+
+        if subtool == "Think":
+            if thought is None:
+                raise ValueError("thought is required for Think subtool")
+
+            return await think(thought, chat_id)
     except Exception:
         logging.error("Exception", exc_info=True)
         raise

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -350,6 +350,10 @@ Records the user's verbatim prompt text for each interaction after the initial o
 You should call this tool with the user's exact message at the beginning of each response.
 This tool must be called in every response except for the first one where InitProject was used.  Do NOT include documents or other attachments, only the text prompt.
 
+## Think chat_id thought
+
+Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.
+
 ## LS chat_id path
 
 Lists files and directories in a given path. The path parameter must be an absolute path, not a relative path. You should generally prefer the Glob and Grep tools, if you know which directories to search.
@@ -383,7 +387,7 @@ for arguments containing spaces, etc.).
 ## Summary
 
 Args:
-    subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, UserPrompt, RunCommand)
+    subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, UserPrompt, RunCommand, Think)
     path: The path to the file or directory to operate on
     content: Content for WriteFile subtool
     old_string: String to replace for EditFile subtool
@@ -393,6 +397,7 @@ Args:
     description: Short description of the change (for WriteFile/EditFile)
     arguments: A string containing space-separated arguments for RunCommand subtool
     user_prompt: The user's verbatim text (for UserPrompt subtool)
+    thought: The thought content (for Think subtool)
     chat_id: A unique ID to identify the chat session (required for all tools EXCEPT InitProject)
 
 # Chat ID

--- a/codemcp/tools/think.py
+++ b/codemcp/tools/think.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import logging
+
+__all__ = [
+    "think",
+]
+
+
+async def think(thought: str, chat_id: str | None = None) -> str:
+    """Use this tool to think about something without obtaining new information or changing the database.
+
+    Args:
+        thought: The thought to log
+        chat_id: The unique ID of the current chat session
+
+    Returns:
+        A confirmation message that the thought was logged
+    """
+    # Log the thought but don't actually do anything with it
+    logging.info(f"[{chat_id}] Thought: {thought}")
+
+    # Return a simple confirmation message
+    return f"Thought logged: {thought}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192
* __->__ #188
* #190
* #189

Add a think tool. It doesn't have to actually do anything internally. Here's the tool instruction:

```
Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.
```

It takes one argument thought: str.

```git-revs
b1390e4  (Base revision)
2cfcc49  Create think tool implementation
5dbd031  Import think tool
ad50e42  Add think tool parameters
ca53db9  Add thought parameter to provided parameters
fa16355  Add thought parameter to function signature
b21bd30  Add Think tool handler in main.py
9defde0  Update function docstring to include Think tool
28e7cc6  Fix thought parameter to not use user_prompt as default
5f172f4  Add Think tool to system prompt in init_project.py
3da4842  Add thought parameter to Args section in init_project.py
HEAD     Auto-commit format changes
```

codemcp-id: 0-feat-add-think-tool-for-complex-reasoning