### PR TITLE
feat: add tool for git rm functionality

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -11,6 +11,7 @@ from .tools.grep import grep_files
 from .tools.init_project import init_project
 from .tools.ls import ls_directory
 from .tools.read_file import read_file_content
+from .tools.rm import rm_file
 from .tools.run_command import run_command
 from .tools.user_prompt import user_prompt as user_prompt_tool
 from .tools.write_file import write_file_content
@@ -87,6 +88,7 @@ async def codemcp(
             "RunCommand": {"path", "command", "arguments", "chat_id"},
             "Grep": {"pattern", "path", "include", "chat_id"},
             "Glob": {"pattern", "path", "limit", "offset", "chat_id"},
+            "RM": {"path", "description", "chat_id"},
         }
 
         # Check if subtool exists
@@ -274,6 +276,14 @@ async def codemcp(
                 raise ValueError("user_prompt is required for UserPrompt subtool")
 
             return await user_prompt_tool(user_prompt, chat_id)
+
+        if subtool == "RM":
+            if path is None:
+                raise ValueError("path is required for RM subtool")
+            if description is None:
+                raise ValueError("description is required for RM subtool")
+
+            return await rm_file(path, description, chat_id)
     except Exception:
         logging.error("Exception", exc_info=True)
         raise

--- a/codemcp/tools/__init__.py
+++ b/codemcp/tools/__init__.py
@@ -1,2 +1,8 @@
 #!/usr/bin/env python3
 # Implement code_command.py utilities here
+
+from .rm import rm_file
+
+__all__ = [
+    "rm_file",
+]

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -380,17 +380,31 @@ arguments using shell-style tokenization (spaces separate arguments, quotes can 
 for arguments containing spaces, etc.).
 {_generate_command_docs(command_docs)}
 
+## RM chat_id path description
+
+Removes a file using git rm and commits the change.
+Provide a short description of why the file is being removed.
+
+Before using this tool:
+1. Ensure the file exists and is tracked by git
+2. Provide a meaningful description of why the file is being removed
+
+Args:
+    path: The path to the file to remove (can be relative to the project root or absolute)
+    description: Short description of why the file is being removed
+    chat_id: The unique ID to identify the chat session
+
 ## Summary
 
 Args:
-    subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, UserPrompt, RunCommand)
+    subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, UserPrompt, RunCommand, RM)
     path: The path to the file or directory to operate on
     content: Content for WriteFile subtool
     old_string: String to replace for EditFile subtool
     new_string: Replacement string for EditFile subtool
     offset: Line offset for ReadFile subtool
     limit: Line limit for ReadFile subtool
-    description: Short description of the change (for WriteFile/EditFile)
+    description: Short description of the change (for WriteFile/EditFile/RM)
     arguments: A string containing space-separated arguments for RunCommand subtool
     user_prompt: The user's verbatim text (for UserPrompt subtool)
     chat_id: A unique ID to identify the chat session (required for all tools EXCEPT InitProject)

--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import re
+
+from ..common import normalize_file_path
+from ..git import commit_changes, get_repository_root
+from ..shell import run_command
+
+__all__ = [
+    "rm_file",
+]
+
+
+async def rm_file(
+    path: str,
+    description: str,
+    chat_id: str = None,
+) -> str:
+    """Remove a file using git rm.
+
+    Args:
+        path: The path to the file to remove (can be absolute or relative to repository root)
+        description: Short description of why the file is being removed
+        chat_id: The unique ID of the current chat session
+
+    Returns:
+        A string containing the result of the removal operation
+    """
+    try:
+        # Use the directory from the path as our starting point
+        file_path = normalize_file_path(path)
+        dir_path = os.path.dirname(file_path) if os.path.dirname(file_path) else "."
+
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File does not exist: {path}")
+
+        if not os.path.isfile(file_path):
+            raise ValueError(f"Path is not a file: {path}")
+
+        # Rather than using our initial directory, we should first try to find the git repo
+        # that contains our file. Start with our file's directory.
+        try:
+            # Get git repository root
+            git_root = await get_repository_root(dir_path)
+            # Fix git root path - ensure it's normalized the same way as our file path
+            git_root = normalize_file_path(git_root)
+        except Exception:
+            # If we can't get the repository root, we're not in a git repository
+            logging.error(f"Directory is not a git repository: {dir_path}")
+            raise ValueError(f"Directory is not a git repository: {dir_path}")
+
+        # Function to normalize paths for comparison
+        def normalize_path_for_comparison(path):
+            # Convert to absolute path
+            path = os.path.abspath(path)
+            # Handle symbolic links
+            if os.path.islink(path):
+                path = os.path.realpath(path)
+            # Normalize path separators
+            path = path.replace("\\", "/")
+            # Remove trailing slash
+            path = path.rstrip("/")
+            # Handle macOS /private/tmp vs /tmp
+            path = re.sub(r"^/private(/tmp/.*)", r"\1", path)
+            return path
+
+        # Normalize paths for comparison
+        norm_file_path = normalize_path_for_comparison(file_path)
+        norm_git_root = normalize_path_for_comparison(git_root)
+
+        # Check if file is in the git repo
+        if not norm_file_path.startswith(norm_git_root):
+            msg = f"Path {file_path} is not within the git repository at {git_root}"
+            logging.error(msg)
+            raise ValueError(msg)
+
+        # Get the relative path
+        os.path.relpath(file_path, git_root)
+
+        # Run git rm on the file - just use the basename to be safe
+        file_basename = os.path.basename(file_path)
+        logging.info(f"Running git rm on file: {file_basename}")
+
+        # Before running git rm, we need to change to the directory containing the file
+        # to avoid path issues
+        file_dir = os.path.dirname(file_path)
+        if not file_dir:
+            file_dir = git_root
+
+        try:
+            # Check if the file is tracked by git
+            await run_command(
+                ["git", "ls-files", "--error-unmatch", file_basename],
+                cwd=file_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            # If we get here, the file is tracked by git, so we can remove it
+            await run_command(
+                ["git", "rm", file_basename],
+                cwd=file_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except Exception as e:
+            logging.error(f"Error running git rm: {e}")
+            raise
+
+        # Commit the changes
+        logging.info(f"Committing removal of file: {file_basename}")
+        success, commit_message = await commit_changes(
+            git_root,
+            f"Remove {file_basename}: {description}",
+            chat_id,
+            commit_all=False,  # No need for commit_all since git rm already stages the change
+        )
+
+        if success:
+            return f"Successfully removed file {file_basename}."
+        else:
+            return f"File {file_basename} was removed but failed to commit: {commit_message}"
+
+    except Exception as e:
+        error_msg = f"Error removing file: {e}"
+        logging.error(error_msg)
+        return f"Error: {error_msg}"

--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -28,104 +28,89 @@ async def rm_file(
     Returns:
         A string containing the result of the removal operation
     """
-    try:
-        # Use the directory from the path as our starting point
-        file_path = normalize_file_path(path)
-        dir_path = os.path.dirname(file_path) if os.path.dirname(file_path) else "."
+    # Use the directory from the path as our starting point
+    file_path = normalize_file_path(path)
+    dir_path = os.path.dirname(file_path) if os.path.dirname(file_path) else "."
 
-        if not os.path.exists(file_path):
-            raise FileNotFoundError(f"File does not exist: {path}")
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File does not exist: {path}")
 
-        if not os.path.isfile(file_path):
-            raise ValueError(f"Path is not a file: {path}")
+    if not os.path.isfile(file_path):
+        raise ValueError(f"Path is not a file: {path}")
 
-        # Rather than using our initial directory, we should first try to find the git repo
-        # that contains our file. Start with our file's directory.
-        try:
-            # Get git repository root
-            git_root = await get_repository_root(dir_path)
-            # Fix git root path - ensure it's normalized the same way as our file path
-            git_root = normalize_file_path(git_root)
-        except Exception:
-            # If we can't get the repository root, we're not in a git repository
-            logging.error(f"Directory is not a git repository: {dir_path}")
-            raise ValueError(f"Directory is not a git repository: {dir_path}")
+    # Get git repository root
+    git_root = await get_repository_root(dir_path)
+    # Fix git root path - ensure it's normalized the same way as our file path
+    git_root = normalize_file_path(git_root)
 
-        # Function to normalize paths for comparison
-        def normalize_path_for_comparison(path):
-            # Convert to absolute path
-            path = os.path.abspath(path)
-            # Handle symbolic links
-            if os.path.islink(path):
-                path = os.path.realpath(path)
-            # Normalize path separators
-            path = path.replace("\\", "/")
-            # Remove trailing slash
-            path = path.rstrip("/")
-            # Handle macOS /private/tmp vs /tmp
-            path = re.sub(r"^/private(/tmp/.*)", r"\1", path)
-            return path
+    # Function to normalize paths for comparison
+    def normalize_path_for_comparison(path):
+        # Convert to absolute path
+        path = os.path.abspath(path)
+        # Handle symbolic links
+        if os.path.islink(path):
+            path = os.path.realpath(path)
+        # Normalize path separators
+        path = path.replace("\\", "/")
+        # Remove trailing slash
+        path = path.rstrip("/")
+        # Handle macOS /private/tmp vs /tmp
+        path = re.sub(r"^/private(/tmp/.*)", r"\1", path)
+        return path
 
-        # Normalize paths for comparison
-        norm_file_path = normalize_path_for_comparison(file_path)
-        norm_git_root = normalize_path_for_comparison(git_root)
+    # Normalize paths for comparison
+    norm_file_path = normalize_path_for_comparison(file_path)
+    norm_git_root = normalize_path_for_comparison(git_root)
 
-        # Check if file is in the git repo
-        if not norm_file_path.startswith(norm_git_root):
-            msg = f"Path {file_path} is not within the git repository at {git_root}"
-            logging.error(msg)
-            raise ValueError(msg)
+    # Check if file is in the git repo
+    if not norm_file_path.startswith(norm_git_root):
+        msg = f"Path {file_path} is not within the git repository at {git_root}"
+        logging.error(msg)
+        raise ValueError(msg)
 
-        # Get the relative path
-        os.path.relpath(file_path, git_root)
+    # Get the relative path
+    os.path.relpath(file_path, git_root)
 
-        # Run git rm on the file - just use the basename to be safe
-        file_basename = os.path.basename(file_path)
-        logging.info(f"Running git rm on file: {file_basename}")
+    # Run git rm on the file - just use the basename to be safe
+    file_basename = os.path.basename(file_path)
+    logging.info(f"Running git rm on file: {file_basename}")
 
-        # Before running git rm, we need to change to the directory containing the file
-        # to avoid path issues
-        file_dir = os.path.dirname(file_path)
-        if not file_dir:
-            file_dir = git_root
+    # Before running git rm, we need to change to the directory containing the file
+    # to avoid path issues
+    file_dir = os.path.dirname(file_path)
+    if not file_dir:
+        file_dir = git_root
 
-        try:
-            # Check if the file is tracked by git
-            await run_command(
-                ["git", "ls-files", "--error-unmatch", file_basename],
-                cwd=file_dir,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
+    # Check if the file is tracked by git
+    await run_command(
+        ["git", "ls-files", "--error-unmatch", file_basename],
+        cwd=file_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
-            # If we get here, the file is tracked by git, so we can remove it
-            await run_command(
-                ["git", "rm", file_basename],
-                cwd=file_dir,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except Exception as e:
-            logging.error(f"Error running git rm: {e}")
-            raise
+    # If we get here, the file is tracked by git, so we can remove it
+    await run_command(
+        ["git", "rm", file_basename],
+        cwd=file_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
-        # Commit the changes
-        logging.info(f"Committing removal of file: {file_basename}")
-        success, commit_message = await commit_changes(
-            git_root,
-            f"Remove {file_basename}: {description}",
-            chat_id,
-            commit_all=False,  # No need for commit_all since git rm already stages the change
+    # Commit the changes
+    logging.info(f"Committing removal of file: {file_basename}")
+    success, commit_message = await commit_changes(
+        git_root,
+        f"Remove {file_basename}: {description}",
+        chat_id,
+        commit_all=False,  # No need for commit_all since git rm already stages the change
+    )
+
+    if success:
+        return f"Successfully removed file {file_basename}."
+    else:
+        return (
+            f"File {file_basename} was removed but failed to commit: {commit_message}"
         )
-
-        if success:
-            return f"Successfully removed file {file_basename}."
-        else:
-            return f"File {file_basename} was removed but failed to commit: {commit_message}"
-
-    except Exception as e:
-        error_msg = f"Error removing file: {e}"
-        logging.error(error_msg)
-        return f"Error: {error_msg}"

--- a/e2e/test_rm.py
+++ b/e2e/test_rm.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""End-to-end tests for the rm tool."""
+
+import os
+import unittest
+
+from codemcp.testing import MCPEndToEndTestCase
+
+
+class RMTest(MCPEndToEndTestCase):
+    """Test the RM subtool functionality."""
+
+    async def test_rm_file(self):
+        """Test removing a file using the RM subtool."""
+        # Create a test file
+        test_file_path = os.path.join(self.temp_dir.name, "file_to_remove.txt")
+        with open(test_file_path, "w") as f:
+            f.write("This file will be removed")
+
+        # Add the file using git
+        await self.git_run(["add", "file_to_remove.txt"])
+        await self.git_run(["commit", "-m", "Add file that will be removed"])
+
+        # Initial count of commits
+        initial_log = await self.git_run(
+            ["log", "--oneline"], capture_output=True, text=True
+        )
+        initial_commit_count = len(initial_log.strip().split("\n"))
+
+        async with self.create_client_session() as session:
+            # Get a valid chat_id
+            chat_id = await self.get_chat_id(session)
+
+            # For debugging, print some path information
+            print(f"DEBUG - Test file path: {test_file_path}")
+            # Check if file exists
+            print(f"DEBUG - File exists before RM: {os.path.exists(test_file_path)}")
+
+            # Call the RM tool with the chat_id - use absolute path
+            result = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "RM",
+                    "path": test_file_path,  # Use absolute path
+                    "description": "Test file removal",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Print the result for debugging
+            print(f"DEBUG - RM result: {result}")
+
+            # Check that the file no longer exists
+            print(f"DEBUG - File exists after RM: {os.path.exists(test_file_path)}")
+            self.assertFalse(
+                os.path.exists(test_file_path), "File should have been removed"
+            )
+
+            # Verify the output message indicates success
+            self.assertIn("Successfully removed file", result)
+
+            # Verify a commit was created for the removal
+            final_log = await self.git_run(
+                ["log", "--oneline"], capture_output=True, text=True
+            )
+            final_commit_count = len(final_log.strip().split("\n"))
+            self.assertEqual(
+                final_commit_count,
+                initial_commit_count + 1,
+                "Should have one more commit",
+            )
+
+            # Verify the commit message contains the description
+            latest_commit_msg = await self.git_run(
+                ["log", "-1", "--pretty=%B"], capture_output=True, text=True
+            )
+            self.assertIn("Remove file_to_remove.txt", latest_commit_msg)
+            self.assertIn("Test file removal", latest_commit_msg)
+
+    async def test_rm_file_does_not_exist(self):
+        """Test attempting to remove a non-existent file."""
+        async with self.create_client_session() as session:
+            # Get a valid chat_id
+            chat_id = await self.get_chat_id(session)
+
+            # Attempt to remove a file that doesn't exist
+            result = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "RM",
+                    "path": "non_existent_file.txt",
+                    "description": "Remove non-existent file",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Verify the operation failed with proper error message
+            self.assertIn("Error", result)
+            self.assertIn("does not exist", result)
+
+    async def test_rm_outside_repo(self):
+        """Test attempting to remove a file outside the repository."""
+        # Create a file outside the repository
+        outside_dir = os.path.join(os.path.dirname(self.temp_dir.name), "outside_repo")
+        os.makedirs(outside_dir, exist_ok=True)
+        outside_file = os.path.join(outside_dir, "outside_file.txt")
+        with open(outside_file, "w") as f:
+            f.write("This file is outside the repository")
+
+        async with self.create_client_session() as session:
+            # Get a valid chat_id
+            chat_id = await self.get_chat_id(session)
+
+            # Attempt to remove the file (using absolute path)
+            result = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "RM",
+                    "path": outside_file,
+                    "description": "Remove file outside repo",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Verify the operation failed with proper error message
+            self.assertIn("Error", result)
+            # Could be either "not a git repository" or "not within the git repository"
+            self.assertTrue(
+                "not a git repository" in result
+                or "not within the git repository" in result,
+                f"Expected git repository error not found in: {result}",
+            )
+
+            # Ensure the file still exists
+            self.assertTrue(
+                os.path.exists(outside_file), "Outside file should still exist"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/e2e/test_rm.py
+++ b/e2e/test_rm.py
@@ -85,8 +85,8 @@ class RMTest(MCPEndToEndTestCase):
             # Get a valid chat_id
             chat_id = await self.get_chat_id(session)
 
-            # Attempt to remove a file that doesn't exist
-            result = await self.call_tool_assert_success(
+            # Attempt to remove a file that doesn't exist - should fail
+            result = await self.call_tool_assert_error(
                 session,
                 "codemcp",
                 {
@@ -98,8 +98,7 @@ class RMTest(MCPEndToEndTestCase):
             )
 
             # Verify the operation failed with proper error message
-            self.assertIn("Error", result)
-            self.assertIn("does not exist", result)
+            self.assertIn("File does not exist", result)
 
     async def test_rm_outside_repo(self):
         """Test attempting to remove a file outside the repository."""
@@ -114,8 +113,8 @@ class RMTest(MCPEndToEndTestCase):
             # Get a valid chat_id
             chat_id = await self.get_chat_id(session)
 
-            # Attempt to remove the file (using absolute path)
-            result = await self.call_tool_assert_success(
+            # Attempt to remove the file (using absolute path) - should fail
+            result = await self.call_tool_assert_error(
                 session,
                 "codemcp",
                 {
@@ -127,11 +126,10 @@ class RMTest(MCPEndToEndTestCase):
             )
 
             # Verify the operation failed with proper error message
-            self.assertIn("Error", result)
-            # Could be either "not a git repository" or "not within the git repository"
+            # Could be either form of the git error message
             self.assertTrue(
-                "not a git repository" in result
-                or "not within the git repository" in result,
+                "fatal: not a git repository" in result
+                or "not a git repository" in result,
                 f"Expected git repository error not found in: {result}",
             )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192
* #188
* #190
* __->__ #189

Add an rm tool that will run git rm on fike.

```git-revs
fdd8c90  (Base revision)
e8ba5d6  Create rm tool implementation for git rm functionality
40da907  Add import for the rm_file function
9d47b06  Add RM subtool parameters to expected_params dictionary
72743f1  Add RM subtool handler to the function
b407f37  Update tools/__init__.py to expose rm_file function
1aa4e67  Add RM tool documentation to init_project system prompt
cc82b0d  Create end-to-end test for the RM tool
fb68528  Fix test to use proper test method call pattern
54a7c39  Fix bug: Replace undefined project_dir with path
5341cc8  Update rm_file function signature to match other tools
f8a4198  Update rm_file git repository checks
7d21f04  Update rm_file to use rel_file_path in git commands
766b294  Update main.py to use new rm_file function signature
c5eb917  Use absolute path in test_rm_file test
1788110  Improve git repository path handling in rm_file
0d2975a  Update test_rm_outside_repo to handle different error messages
1fcd6bb  Improve path normalization and comparison in rm_file
4972e4a  Add debug logging to test_rm_file
c5fe107  Add re module import
8057cc6  Improve path normalization for macOS /private/tmp vs /tmp issue
8c240d2  Change git rm approach to use basename and work in file directory
96956a9  Use file_basename in commit message
f4653eb  Use file_basename in success and error messages
86f6068  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 201-feat-add-tool-for-git-rm-functionality