### PR TITLE
fix: resolve path validation issue in rm.py

### DIFF
--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -54,8 +54,8 @@ async def rm_file(
         path = path.replace("\\", "/")
         # Remove trailing slash
         path = path.rstrip("/")
-        # Handle macOS /private/tmp vs /tmp
-        path = re.sub(r"^/private(/tmp/.*)", r"\1", path)
+        # Handle macOS /private/ prefix (macOS symlinks /tmp, /var to /private/tmp, /private/var)
+        path = re.sub(r"^/private(/.*)", r"\1", path)
         return path
 
     # Normalize paths for comparison


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192
* #188
* __->__ #190
* #189

ERROR    root:rm.py:68 Path /var/folders/zp/xff7r1c96vj9b2f375x9r0340000gn/T/tmp3mqrkqxd/file_to_remove.txt is not within the git repository at /private/var/folders/zp/xff7r1c96vj9b2f375x9r0340000gn/T/tmp3mqrkqxd
ERROR    root:main.py:300 Exception
Traceback (most recent call last):
  File "/Users/ezyang/Dev/codemcp/codemcp/main.py", line 292, in codemcp
    return await rm_file(path, description, chat_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/Dev/codemcp/codemcp/tools/rm.py", line 69, in rm_file
    raise ValueError(msg)
ValueError: Path /var/folders/zp/xff7r1c96vj9b2f375x9r0340000gn/T/tmp3mqrkqxd/file_to_remove.txt is not within the git repository at /private/var/folders/zp/xff7r1c96vj9b2f375x9r0340000gn/T/tmp3mqrkqxd
========================================= short test summary info =========================================
FAILED e2e/test_rm.py::RMTest::test_rm_file - ValueError: Path /var/folders/zp/xff7r1c96vj9b2f375x9r0340000gn/T/tmp3mqrkqxd/file_to_remove.txt is no...

```git-revs
c84eb99  (Base revision)
HEAD     Improve path normalization to handle all macOS /private/ prefixes
```

codemcp-id: 202-fix-resolve-path-validation-issue-in-rm-py