### PR TITLE
refactor: move pytest configs from run_test.sh to pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 
+[tool.pytest.ini_options]
+# Pytest configuration
+testpaths = ["tests", "e2e"]
+addopts = "-n auto --tb=native"
+
 [tool.pyright]
 # Pyright configuration with strict settings
 include = ["codemcp"]

--- a/run_test.sh
+++ b/run_test.sh
@@ -2,4 +2,4 @@
 set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
-"${SCRIPT_DIR}/.venv/bin/python" -m pytest -n auto --tb=native $@
+"${SCRIPT_DIR}/.venv/bin/python" -m pytest $@


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #195
* #193
* #194
* __->__ #191
* #192

run_test.sh manually applies some pytest configs via args, put these configs in pytest config so that vanilla pytest gets them.

```git-revs
a961d4c  (Base revision)
400f012  Add pytest configuration section to pyproject.toml
dd04ba5  Remove redundant pytest args from run_test.sh
HEAD     Remove invalid pytest configuration option
```

codemcp-id: 0-refactor-move-pytest-configs-from-run-test-sh-to-p