### PR TITLE
feat: Add Git read-only tools

### DIFF
--- a/codemcp/tools/__init__.py
+++ b/codemcp/tools/__init__.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 # Implement code_command.py utilities here
 
+from .git_blame import git_blame
+from .git_diff import git_diff
+from .git_log import git_log
+from .git_show import git_show
 from .rm import rm_file
 
 __all__ = [
+    "git_blame",
+    "git_diff",
+    "git_log",
+    "git_show",
     "rm_file",
 ]

--- a/codemcp/tools/git_blame.py
+++ b/codemcp/tools/git_blame.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import logging
+import shlex
+import time
+from typing import Any
+
+from ..common import normalize_file_path
+from ..git import is_git_repository
+from ..shell import run_command
+
+__all__ = [
+    "git_blame",
+    "render_result_for_assistant",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
+]
+
+TOOL_NAME_FOR_PROMPT = "GitBlame"
+DESCRIPTION = """
+Shows what revision and author last modified each line of a file using git blame.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git blame path/to/file  # Show blame information for a file
+  git blame -L 10,20 path/to/file  # Show blame information for lines 10-20
+  git blame -w path/to/file  # Ignore whitespace changes
+"""
+
+
+async def git_blame(
+    arguments: str | None = None,
+    path: str | None = None,
+    chat_id: str | None = None,
+    signal=None,
+) -> dict[str, Any]:
+    """Execute git blame with the provided arguments.
+
+    Args:
+        arguments: Optional arguments to pass to git blame as a string
+        path: The directory to execute the command in (must be in a git repository)
+        chat_id: The unique ID of the current chat session
+        signal: Optional abort signal to terminate the subprocess
+
+    Returns:
+        A dictionary with execution stats and git blame output
+    """
+    start_time = time.time()
+
+    if path is None:
+        raise ValueError("Path must be provided for git blame")
+
+    # Normalize the directory path
+    absolute_path = normalize_file_path(path)
+
+    # Verify this is a git repository
+    if not await is_git_repository(absolute_path):
+        raise ValueError(f"The provided path is not in a git repository: {path}")
+
+    # Build command
+    cmd = ["git", "blame"]
+
+    # Add additional arguments if provided
+    if arguments:
+        parsed_args = shlex.split(arguments)
+        cmd.extend(parsed_args)
+
+    logging.debug(f"Executing git blame command: {' '.join(cmd)}")
+
+    try:
+        # Execute git blame command asynchronously
+        result = await run_command(
+            cmd=cmd,
+            cwd=absolute_path,
+            capture_output=True,
+            text=True,
+            check=False,  # Don't raise exception if git blame fails
+        )
+
+        # Process results
+        if result.returncode != 0:
+            logging.error(
+                f"git blame failed with exit code {result.returncode}: {result.stderr}"
+            )
+            error_message = f"Error: {result.stderr}"
+            return {
+                "output": error_message,
+                "durationMs": int((time.time() - start_time) * 1000),
+                "resultForAssistant": error_message,
+            }
+
+        # Calculate execution time
+        execution_time = int(
+            (time.time() - start_time) * 1000
+        )  # Convert to milliseconds
+
+        # Prepare output
+        output = {
+            "output": result.stdout,
+            "durationMs": execution_time,
+        }
+
+        # Add formatted result for assistant
+        output["resultForAssistant"] = render_result_for_assistant(output)
+
+        return output
+    except Exception as e:
+        logging.exception(f"Error executing git blame: {e!s}")
+        error_message = f"Error executing git blame: {e!s}"
+        return {
+            "output": error_message,
+            "durationMs": int((time.time() - start_time) * 1000),
+            "resultForAssistant": error_message,
+        }
+
+
+def render_result_for_assistant(output: dict[str, Any]) -> str:
+    """Render the results in a format suitable for the assistant.
+
+    Args:
+        output: The git blame output dictionary
+
+    Returns:
+        A formatted string representation of the results
+    """
+    return output.get("output", "")

--- a/codemcp/tools/git_diff.py
+++ b/codemcp/tools/git_diff.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import logging
+import shlex
+import time
+from typing import Any
+
+from ..common import normalize_file_path
+from ..git import is_git_repository
+from ..shell import run_command
+
+__all__ = [
+    "git_diff",
+    "render_result_for_assistant",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
+]
+
+TOOL_NAME_FOR_PROMPT = "GitDiff"
+DESCRIPTION = """
+Shows differences between commits, commit and working tree, etc. using git diff.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git diff  # Show changes between working directory and index
+  git diff HEAD~1  # Show changes between current commit and previous commit
+  git diff branch1 branch2  # Show differences between two branches
+  git diff --stat  # Show summary of changes instead of full diff
+"""
+
+
+async def git_diff(
+    arguments: str | None = None,
+    path: str | None = None,
+    chat_id: str | None = None,
+    signal=None,
+) -> dict[str, Any]:
+    """Execute git diff with the provided arguments.
+
+    Args:
+        arguments: Optional arguments to pass to git diff as a string
+        path: The directory to execute the command in (must be in a git repository)
+        chat_id: The unique ID of the current chat session
+        signal: Optional abort signal to terminate the subprocess
+
+    Returns:
+        A dictionary with execution stats and git diff output
+    """
+    start_time = time.time()
+
+    if path is None:
+        raise ValueError("Path must be provided for git diff")
+
+    # Normalize the directory path
+    absolute_path = normalize_file_path(path)
+
+    # Verify this is a git repository
+    if not await is_git_repository(absolute_path):
+        raise ValueError(f"The provided path is not in a git repository: {path}")
+
+    # Build command
+    cmd = ["git", "diff"]
+
+    # Add additional arguments if provided
+    if arguments:
+        parsed_args = shlex.split(arguments)
+        cmd.extend(parsed_args)
+
+    logging.debug(f"Executing git diff command: {' '.join(cmd)}")
+
+    try:
+        # Execute git diff command asynchronously
+        result = await run_command(
+            cmd=cmd,
+            cwd=absolute_path,
+            capture_output=True,
+            text=True,
+            check=False,  # Don't raise exception if git diff fails
+        )
+
+        # Process results
+        if result.returncode != 0:
+            logging.error(
+                f"git diff failed with exit code {result.returncode}: {result.stderr}"
+            )
+            error_message = f"Error: {result.stderr}"
+            return {
+                "output": error_message,
+                "durationMs": int((time.time() - start_time) * 1000),
+                "resultForAssistant": error_message,
+            }
+
+        # Calculate execution time
+        execution_time = int(
+            (time.time() - start_time) * 1000
+        )  # Convert to milliseconds
+
+        # Prepare output
+        output = {
+            "output": result.stdout,
+            "durationMs": execution_time,
+        }
+
+        # Add formatted result for assistant
+        output["resultForAssistant"] = render_result_for_assistant(output)
+
+        return output
+    except Exception as e:
+        logging.exception(f"Error executing git diff: {e!s}")
+        error_message = f"Error executing git diff: {e!s}"
+        return {
+            "output": error_message,
+            "durationMs": int((time.time() - start_time) * 1000),
+            "resultForAssistant": error_message,
+        }
+
+
+def render_result_for_assistant(output: dict[str, Any]) -> str:
+    """Render the results in a format suitable for the assistant.
+
+    Args:
+        output: The git diff output dictionary
+
+    Returns:
+        A formatted string representation of the results
+    """
+    return output.get("output", "")

--- a/codemcp/tools/git_log.py
+++ b/codemcp/tools/git_log.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import logging
+import shlex
+import time
+from typing import Any
+
+from ..common import normalize_file_path
+from ..git import is_git_repository
+from ..shell import run_command
+
+__all__ = [
+    "git_log",
+    "render_result_for_assistant",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
+]
+
+TOOL_NAME_FOR_PROMPT = "GitLog"
+DESCRIPTION = """
+Shows commit logs using git log.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git log --oneline -n 5  # Show the last 5 commits in oneline format
+  git log --author="John Doe" --since="2023-01-01"  # Show commits by an author since a date
+  git log -- path/to/file  # Show commit history for a specific file
+"""
+
+
+async def git_log(
+    arguments: str | None = None,
+    path: str | None = None,
+    chat_id: str | None = None,
+    signal=None,
+) -> dict[str, Any]:
+    """Execute git log with the provided arguments.
+
+    Args:
+        arguments: Optional arguments to pass to git log as a string
+        path: The directory to execute the command in (must be in a git repository)
+        chat_id: The unique ID of the current chat session
+        signal: Optional abort signal to terminate the subprocess
+
+    Returns:
+        A dictionary with execution stats and git log output
+    """
+    start_time = time.time()
+
+    if path is None:
+        raise ValueError("Path must be provided for git log")
+
+    # Normalize the directory path
+    absolute_path = normalize_file_path(path)
+
+    # Verify this is a git repository
+    if not await is_git_repository(absolute_path):
+        raise ValueError(f"The provided path is not in a git repository: {path}")
+
+    # Build command
+    cmd = ["git", "log"]
+
+    # Add additional arguments if provided
+    if arguments:
+        parsed_args = shlex.split(arguments)
+        cmd.extend(parsed_args)
+
+    logging.debug(f"Executing git log command: {' '.join(cmd)}")
+
+    try:
+        # Execute git log command asynchronously
+        result = await run_command(
+            cmd=cmd,
+            cwd=absolute_path,
+            capture_output=True,
+            text=True,
+            check=False,  # Don't raise exception if git log fails
+        )
+
+        # Process results
+        if result.returncode != 0:
+            logging.error(
+                f"git log failed with exit code {result.returncode}: {result.stderr}"
+            )
+            error_message = f"Error: {result.stderr}"
+            return {
+                "output": error_message,
+                "durationMs": int((time.time() - start_time) * 1000),
+                "resultForAssistant": error_message,
+            }
+
+        # Calculate execution time
+        execution_time = int(
+            (time.time() - start_time) * 1000
+        )  # Convert to milliseconds
+
+        # Prepare output
+        output = {
+            "output": result.stdout,
+            "durationMs": execution_time,
+        }
+
+        # Add formatted result for assistant
+        output["resultForAssistant"] = render_result_for_assistant(output)
+
+        return output
+    except Exception as e:
+        logging.exception(f"Error executing git log: {e!s}")
+        error_message = f"Error executing git log: {e!s}"
+        return {
+            "output": error_message,
+            "durationMs": int((time.time() - start_time) * 1000),
+            "resultForAssistant": error_message,
+        }
+
+
+def render_result_for_assistant(output: dict[str, Any]) -> str:
+    """Render the results in a format suitable for the assistant.
+
+    Args:
+        output: The git log output dictionary
+
+    Returns:
+        A formatted string representation of the results
+    """
+    return output.get("output", "")

--- a/codemcp/tools/git_show.py
+++ b/codemcp/tools/git_show.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import logging
+import shlex
+import time
+from typing import Any
+
+from ..common import normalize_file_path
+from ..git import is_git_repository
+from ..shell import run_command
+
+__all__ = [
+    "git_show",
+    "render_result_for_assistant",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
+]
+
+TOOL_NAME_FOR_PROMPT = "GitShow"
+DESCRIPTION = """
+Shows various types of objects (commits, tags, trees, blobs) using git show.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git show  # Show the most recent commit
+  git show a1b2c3d  # Show a specific commit by hash
+  git show HEAD~3  # Show the commit 3 before HEAD
+  git show v1.0  # Show a tag
+  git show HEAD:path/to/file  # Show a file from a specific commit
+"""
+
+
+async def git_show(
+    arguments: str | None = None,
+    path: str | None = None,
+    chat_id: str | None = None,
+    signal=None,
+) -> dict[str, Any]:
+    """Execute git show with the provided arguments.
+
+    Args:
+        arguments: Optional arguments to pass to git show as a string
+        path: The directory to execute the command in (must be in a git repository)
+        chat_id: The unique ID of the current chat session
+        signal: Optional abort signal to terminate the subprocess
+
+    Returns:
+        A dictionary with execution stats and git show output
+    """
+    start_time = time.time()
+
+    if path is None:
+        raise ValueError("Path must be provided for git show")
+
+    # Normalize the directory path
+    absolute_path = normalize_file_path(path)
+
+    # Verify this is a git repository
+    if not await is_git_repository(absolute_path):
+        raise ValueError(f"The provided path is not in a git repository: {path}")
+
+    # Build command
+    cmd = ["git", "show"]
+
+    # Add additional arguments if provided
+    if arguments:
+        parsed_args = shlex.split(arguments)
+        cmd.extend(parsed_args)
+
+    logging.debug(f"Executing git show command: {' '.join(cmd)}")
+
+    try:
+        # Execute git show command asynchronously
+        result = await run_command(
+            cmd=cmd,
+            cwd=absolute_path,
+            capture_output=True,
+            text=True,
+            check=False,  # Don't raise exception if git show fails
+        )
+
+        # Process results
+        if result.returncode != 0:
+            logging.error(
+                f"git show failed with exit code {result.returncode}: {result.stderr}"
+            )
+            error_message = f"Error: {result.stderr}"
+            return {
+                "output": error_message,
+                "durationMs": int((time.time() - start_time) * 1000),
+                "resultForAssistant": error_message,
+            }
+
+        # Calculate execution time
+        execution_time = int(
+            (time.time() - start_time) * 1000
+        )  # Convert to milliseconds
+
+        # Prepare output
+        output = {
+            "output": result.stdout,
+            "durationMs": execution_time,
+        }
+
+        # Add formatted result for assistant
+        output["resultForAssistant"] = render_result_for_assistant(output)
+
+        return output
+    except Exception as e:
+        logging.exception(f"Error executing git show: {e!s}")
+        error_message = f"Error executing git show: {e!s}"
+        return {
+            "output": error_message,
+            "durationMs": int((time.time() - start_time) * 1000),
+            "resultForAssistant": error_message,
+        }
+
+
+def render_result_for_assistant(output: dict[str, Any]) -> str:
+    """Render the results in a format suitable for the assistant.
+
+    Args:
+        output: The git show output dictionary
+
+    Returns:
+        A formatted string representation of the results
+    """
+    return output.get("output", "")

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -276,6 +276,61 @@ When making changes to files, first understand the file's code conventions. Mimi
 # codemcp tool
 The codemcp tool supports a number of subtools which you should use to perform coding tasks.
 
+## GitLog chat_id path arguments?
+
+Shows commit logs using git log.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git log --oneline -n 5  # Show the last 5 commits in oneline format
+  git log --author="John Doe" --since="2023-01-01"  # Show commits by an author since a date
+  git log -- path/to/file  # Show commit history for a specific file
+
+## GitDiff chat_id path arguments?
+
+Shows differences between commits, commit and working tree, etc. using git diff.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git diff  # Show changes between working directory and index
+  git diff HEAD~1  # Show changes between current commit and previous commit
+  git diff branch1 branch2  # Show differences between two branches
+  git diff --stat  # Show summary of changes instead of full diff
+
+## GitShow chat_id path arguments?
+
+Shows various types of objects (commits, tags, trees, blobs) using git show.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git show  # Show the most recent commit
+  git show a1b2c3d  # Show a specific commit by hash
+  git show HEAD~3  # Show the commit 3 before HEAD
+  git show v1.0  # Show a tag
+  git show HEAD:path/to/file  # Show a file from a specific commit
+
+## GitBlame chat_id path arguments?
+
+Shows what revision and author last modified each line of a file using git blame.
+This tool is read-only and safe to use with any arguments.
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+Example:
+  git blame path/to/file  # Show blame information for a file
+  git blame -L 10,20 path/to/file  # Show blame information for lines 10-20
+  git blame -w path/to/file  # Ignore whitespace changes
+
 ## ReadFile chat_id path offset? limit?
 
 Reads a file from the local filesystem. The path parameter must be an absolute path, not a relative path. By default, it reads up to {MAX_LINES_TO_READ} lines starting from the beginning of the file. You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters. Any lines longer than {MAX_LINE_LENGTH} characters will be truncated. For image files, the tool will display the image for you.

--- a/e2e/test_git_tools.py
+++ b/e2e/test_git_tools.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import pytest
+
+from codemcp.shell import run_command
+from codemcp.tools.git_blame import git_blame
+from codemcp.tools.git_diff import git_diff
+from codemcp.tools.git_log import git_log
+from codemcp.tools.git_show import git_show
+
+
+@pytest.mark.asyncio
+class TestGitTools(unittest.TestCase):
+    """Test the git tools functionality."""
+
+    async def asyncSetUp(self):
+        # Create a temporary directory
+        self.temp_dir = tempfile.mkdtemp()
+
+        # Initialize a git repository
+        await run_command(
+            cmd=["git", "init"], cwd=self.temp_dir, capture_output=True, text=True
+        )
+
+        # Create a sample file
+        self.sample_file = os.path.join(self.temp_dir, "sample.txt")
+        with open(self.sample_file, "w") as f:
+            f.write("Sample content\nLine 2\nLine 3\n")
+
+        # Add and commit the file
+        await run_command(
+            cmd=["git", "config", "user.name", "Test User"],
+            cwd=self.temp_dir,
+            capture_output=True,
+            text=True,
+        )
+        await run_command(
+            cmd=["git", "config", "user.email", "test@example.com"],
+            cwd=self.temp_dir,
+            capture_output=True,
+            text=True,
+        )
+        await run_command(
+            cmd=["git", "add", "sample.txt"],
+            cwd=self.temp_dir,
+            capture_output=True,
+            text=True,
+        )
+        await run_command(
+            cmd=["git", "commit", "-m", "Initial commit"],
+            cwd=self.temp_dir,
+            capture_output=True,
+            text=True,
+        )
+
+        # Modify the file and create another commit
+        with open(self.sample_file, "a") as f:
+            f.write("Line 4\nLine 5\n")
+
+        await run_command(
+            cmd=["git", "add", "sample.txt"],
+            cwd=self.temp_dir,
+            capture_output=True,
+            text=True,
+        )
+        await run_command(
+            cmd=["git", "commit", "-m", "Second commit"],
+            cwd=self.temp_dir,
+            capture_output=True,
+            text=True,
+        )
+
+    async def asyncTearDown(self):
+        # Clean up the temporary directory
+        shutil.rmtree(self.temp_dir)
+
+    async def test_git_log(self):
+        """Test the git_log tool."""
+        # Test with no arguments
+        result = await git_log(path=self.temp_dir)
+        self.assertIn("Initial commit", result["output"])
+        self.assertIn("Second commit", result["output"])
+
+        # Test with arguments
+        result = await git_log(arguments="--oneline -n 1", path=self.temp_dir)
+        self.assertIn("Second commit", result["output"])
+        self.assertNotIn("Initial commit", result["output"])
+
+    async def test_git_diff(self):
+        """Test the git_diff tool."""
+        # Create a change but don't commit it
+        with open(self.sample_file, "a") as f:
+            f.write("Uncommitted change\n")
+
+        # Test with no arguments
+        result = await git_diff(path=self.temp_dir)
+        self.assertIn("Uncommitted change", result["output"])
+
+        # Test with arguments
+        result = await git_diff(arguments="HEAD~1 HEAD", path=self.temp_dir)
+        self.assertIn("Line 4", result["output"])
+
+    async def test_git_show(self):
+        """Test the git_show tool."""
+        # Test with no arguments (should show the latest commit)
+        result = await git_show(path=self.temp_dir)
+        self.assertIn("Second commit", result["output"])
+
+        # Test with arguments
+        result = await git_show(arguments="HEAD~1", path=self.temp_dir)
+        self.assertIn("Initial commit", result["output"])
+
+    async def test_git_blame(self):
+        """Test the git_blame tool."""
+        # Test with file argument
+        result = await git_blame(arguments="sample.txt", path=self.temp_dir)
+        self.assertIn("Test User", result["output"])
+        self.assertIn("Line 2", result["output"])
+
+        # Test with line range
+        result = await git_blame(arguments="-L 4,5 sample.txt", path=self.temp_dir)
+        self.assertIn("Line 4", result["output"])
+        self.assertNotIn("Line 2", result["output"])
+
+    async def test_invalid_path(self):
+        """Test that tools handle invalid paths."""
+        with mock.patch("codemcp.git.is_git_repository", return_value=False):
+            with self.assertRaises(ValueError):
+                await git_log(path="/invalid/path")
+
+            with self.assertRaises(ValueError):
+                await git_diff(path="/invalid/path")
+
+            with self.assertRaises(ValueError):
+                await git_show(path="/invalid/path")
+
+            with self.assertRaises(ValueError):
+                await git_blame(path="/invalid/path")
+
+    async def test_command_failure(self):
+        """Test that tools handle command failures."""
+        # Test with invalid arguments
+        result = await git_log(arguments="--invalid-option", path=self.temp_dir)
+        self.assertIn("Error", result["resultForAssistant"])
+
+        result = await git_diff(arguments="--invalid-option", path=self.temp_dir)
+        self.assertIn("Error", result["resultForAssistant"])
+
+        result = await git_show(arguments="--invalid-option", path=self.temp_dir)
+        self.assertIn("Error", result["resultForAssistant"])
+
+        result = await git_blame(arguments="--invalid-option", path=self.temp_dir)
+        self.assertIn("Error", result["resultForAssistant"])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #195
* #193
* __->__ #194
* #191
* #192

Add the following tools: 'git log', 'git diff', 'git show', 'git blame'. These subcommands are guaranteed to be read only so arguments can be passed through directly. Use a single string with shlex.split to get arguments.

```git-revs
265c785  (Base revision)
bc70bf5  Create git_log.py tool file
d0390dd  Create git_diff.py tool file
8945599  Create git_show.py tool file
964a844  Create git_blame.py tool file
2dfc4b3  Update __init__.py to expose the new Git tools
119a817  Update system prompt with Git tool documentation
d8f0d1a  Create end-to-end test for Git tools
9c61495  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 204-feat-add-git-read-only-tools