### PR TITLE
fix: resolve pytest warnings in test_git_tools.py

### DIFF
--- a/e2e/test_git_tools.py
+++ b/e2e/test_git_tools.py
@@ -1,196 +1,119 @@
 #!/usr/bin/env python3
 
-import asyncio
 import os
-import shutil
-import tempfile
-import unittest
 from unittest import mock
 
-from codemcp.shell import run_command
+from codemcp.testing import MCPEndToEndTestCase
 from codemcp.tools.git_blame import git_blame
 from codemcp.tools.git_diff import git_diff
 from codemcp.tools.git_log import git_log
 from codemcp.tools.git_show import git_show
 
 
-class TestGitTools(unittest.TestCase):
+class TestGitTools(MCPEndToEndTestCase):
     """Test the git tools functionality."""
 
-    def setUp(self):
-        # Create a temporary directory
-        self.temp_dir = tempfile.mkdtemp()
-
-        # Initialize a git repository
-        asyncio.run(self.async_setup())
-
-    async def async_setup(self):
-        # Initialize a git repository
-        await run_command(
-            cmd=["git", "init"], cwd=self.temp_dir, capture_output=True, text=True
-        )
+    async def asyncSetUp(self):
+        # Use the parent class's asyncSetUp to set up test environment
+        await super().asyncSetUp()
 
         # Create a sample file
-        self.sample_file = os.path.join(self.temp_dir, "sample.txt")
+        self.sample_file = os.path.join(self.temp_dir.name, "sample.txt")
         with open(self.sample_file, "w") as f:
             f.write("Sample content\nLine 2\nLine 3\n")
 
-        # Add and commit the file
-        await run_command(
-            cmd=["git", "config", "user.name", "Test User"],
-            cwd=self.temp_dir,
-            capture_output=True,
-            text=True,
-        )
-        await run_command(
-            cmd=["git", "config", "user.email", "test@example.com"],
-            cwd=self.temp_dir,
-            capture_output=True,
-            text=True,
-        )
-        await run_command(
-            cmd=["git", "add", "sample.txt"],
-            cwd=self.temp_dir,
-            capture_output=True,
-            text=True,
-        )
-        await run_command(
-            cmd=["git", "commit", "-m", "Initial commit"],
-            cwd=self.temp_dir,
-            capture_output=True,
-            text=True,
-        )
+        # Add and commit the file (the base class already has git initialized)
+        await self.git_run(["add", "sample.txt"])
+        await self.git_run(["commit", "-m", "Initial commit"])
 
         # Modify the file and create another commit
         with open(self.sample_file, "a") as f:
             f.write("Line 4\nLine 5\n")
 
-        await run_command(
-            cmd=["git", "add", "sample.txt"],
-            cwd=self.temp_dir,
-            capture_output=True,
-            text=True,
-        )
-        await run_command(
-            cmd=["git", "commit", "-m", "Second commit"],
-            cwd=self.temp_dir,
-            capture_output=True,
-            text=True,
-        )
+        await self.git_run(["add", "sample.txt"])
+        await self.git_run(["commit", "-m", "Second commit"])
 
-    def tearDown(self):
-        # Clean up the temporary directory
-        shutil.rmtree(self.temp_dir)
-
-    def test_git_log(self):
+    async def test_git_log(self):
         """Test the git_log tool."""
+        # Test with no arguments
+        result = await git_log(path=self.temp_dir.name)
+        self.assertIn("Initial commit", result["output"])
+        self.assertIn("Second commit", result["output"])
 
-        async def _test():
-            # Test with no arguments
-            result = await git_log(path=self.temp_dir)
-            self.assertIn("Initial commit", result["output"])
-            self.assertIn("Second commit", result["output"])
+        # Test with arguments
+        result = await git_log(arguments="--oneline -n 1", path=self.temp_dir.name)
+        self.assertIn("Second commit", result["output"])
+        self.assertNotIn("Initial commit", result["output"])
 
-            # Test with arguments
-            result = await git_log(arguments="--oneline -n 1", path=self.temp_dir)
-            self.assertIn("Second commit", result["output"])
-            self.assertNotIn("Initial commit", result["output"])
-
-        asyncio.run(_test())
-
-    def test_git_diff(self):
+    async def test_git_diff(self):
         """Test the git_diff tool."""
+        # Create a change but don't commit it
+        with open(self.sample_file, "a") as f:
+            f.write("Uncommitted change\n")
 
-        async def _test():
-            # Create a change but don't commit it
-            with open(self.sample_file, "a") as f:
-                f.write("Uncommitted change\n")
+        # Test with no arguments
+        result = await git_diff(path=self.temp_dir.name)
+        self.assertIn("Uncommitted change", result["output"])
 
-            # Test with no arguments
-            result = await git_diff(path=self.temp_dir)
-            self.assertIn("Uncommitted change", result["output"])
+        # Test with arguments
+        result = await git_diff(arguments="HEAD~1 HEAD", path=self.temp_dir.name)
+        self.assertIn("Line 4", result["output"])
 
-            # Test with arguments
-            result = await git_diff(arguments="HEAD~1 HEAD", path=self.temp_dir)
-            self.assertIn("Line 4", result["output"])
-
-        asyncio.run(_test())
-
-    def test_git_show(self):
+    async def test_git_show(self):
         """Test the git_show tool."""
+        # Test with no arguments (should show the latest commit)
+        result = await git_show(path=self.temp_dir.name)
+        self.assertIn("Second commit", result["output"])
 
-        async def _test():
-            # Test with no arguments (should show the latest commit)
-            result = await git_show(path=self.temp_dir)
-            self.assertIn("Second commit", result["output"])
+        # Test with arguments
+        result = await git_show(arguments="HEAD~1", path=self.temp_dir.name)
+        self.assertIn("Initial commit", result["output"])
 
-            # Test with arguments
-            result = await git_show(arguments="HEAD~1", path=self.temp_dir)
-            self.assertIn("Initial commit", result["output"])
-
-        asyncio.run(_test())
-
-    def test_git_blame(self):
+    async def test_git_blame(self):
         """Test the git_blame tool."""
+        # Test with file argument
+        result = await git_blame(arguments="sample.txt", path=self.temp_dir.name)
+        self.assertIn(
+            "A U Thor", result["output"]
+        )  # MCPEndToEndTestCase sets this author
+        self.assertIn("Line 2", result["output"])
 
-        async def _test():
-            # Test with file argument
-            result = await git_blame(arguments="sample.txt", path=self.temp_dir)
-            self.assertIn("Test User", result["output"])
-            self.assertIn("Line 2", result["output"])
+        # Test with line range
+        result = await git_blame(arguments="-L 4,5 sample.txt", path=self.temp_dir.name)
+        self.assertIn("Line 4", result["output"])
+        self.assertNotIn("Line 2", result["output"])
 
-            # Test with line range
-            result = await git_blame(arguments="-L 4,5 sample.txt", path=self.temp_dir)
-            self.assertIn("Line 4", result["output"])
-            self.assertNotIn("Line 2", result["output"])
-
-        asyncio.run(_test())
-
-    def test_invalid_path(self):
+    async def test_invalid_path(self):
         """Test that tools handle invalid paths."""
+        with mock.patch("codemcp.tools.git_log.is_git_repository", return_value=False):
+            with self.assertRaises(ValueError):
+                await git_log(path="/invalid/path")
 
-        async def _test():
-            with mock.patch(
-                "codemcp.tools.git_log.is_git_repository", return_value=False
-            ):
-                with self.assertRaises(ValueError):
-                    await git_log(path="/invalid/path")
+        with mock.patch("codemcp.tools.git_diff.is_git_repository", return_value=False):
+            with self.assertRaises(ValueError):
+                await git_diff(path="/invalid/path")
 
-            with mock.patch(
-                "codemcp.tools.git_diff.is_git_repository", return_value=False
-            ):
-                with self.assertRaises(ValueError):
-                    await git_diff(path="/invalid/path")
+        with mock.patch("codemcp.tools.git_show.is_git_repository", return_value=False):
+            with self.assertRaises(ValueError):
+                await git_show(path="/invalid/path")
 
-            with mock.patch(
-                "codemcp.tools.git_show.is_git_repository", return_value=False
-            ):
-                with self.assertRaises(ValueError):
-                    await git_show(path="/invalid/path")
+        with mock.patch(
+            "codemcp.tools.git_blame.is_git_repository", return_value=False
+        ):
+            with self.assertRaises(ValueError):
+                await git_blame(path="/invalid/path")
 
-            with mock.patch(
-                "codemcp.tools.git_blame.is_git_repository", return_value=False
-            ):
-                with self.assertRaises(ValueError):
-                    await git_blame(path="/invalid/path")
-
-        asyncio.run(_test())
-
-    def test_command_failure(self):
+    async def test_command_failure(self):
         """Test that tools handle command failures."""
+        # Test with invalid arguments
+        result = await git_log(arguments="--invalid-option", path=self.temp_dir.name)
+        self.assertIn("Error", result["resultForAssistant"])
 
-        async def _test():
-            # Test with invalid arguments
-            result = await git_log(arguments="--invalid-option", path=self.temp_dir)
-            self.assertIn("Error", result["resultForAssistant"])
+        result = await git_diff(arguments="--invalid-option", path=self.temp_dir.name)
+        self.assertIn("Error", result["resultForAssistant"])
 
-            result = await git_diff(arguments="--invalid-option", path=self.temp_dir)
-            self.assertIn("Error", result["resultForAssistant"])
+        result = await git_show(arguments="--invalid-option", path=self.temp_dir.name)
+        self.assertIn("Error", result["resultForAssistant"])
 
-            result = await git_show(arguments="--invalid-option", path=self.temp_dir)
-            self.assertIn("Error", result["resultForAssistant"])
-
-            result = await git_blame(arguments="--invalid-option", path=self.temp_dir)
-            self.assertIn("Error", result["resultForAssistant"])
-
-        asyncio.run(_test())
+        result = await git_blame(arguments="--invalid-option", path=self.temp_dir.name)
+        self.assertIn("Error", result["resultForAssistant"])

--- a/e2e/test_git_tools.py
+++ b/e2e/test_git_tools.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 
+import asyncio
 import os
 import shutil
 import tempfile
 import unittest
 from unittest import mock
-
-import pytest
 
 from codemcp.shell import run_command
 from codemcp.tools.git_blame import git_blame
@@ -15,14 +14,17 @@ from codemcp.tools.git_log import git_log
 from codemcp.tools.git_show import git_show
 
 
-@pytest.mark.asyncio
 class TestGitTools(unittest.TestCase):
     """Test the git tools functionality."""
 
-    async def asyncSetUp(self):
+    def setUp(self):
         # Create a temporary directory
         self.temp_dir = tempfile.mkdtemp()
 
+        # Initialize a git repository
+        asyncio.run(self.async_setup())
+
+    async def async_setup(self):
         # Initialize a git repository
         await run_command(
             cmd=["git", "init"], cwd=self.temp_dir, capture_output=True, text=True
@@ -76,84 +78,119 @@ class TestGitTools(unittest.TestCase):
             text=True,
         )
 
-    async def asyncTearDown(self):
+    def tearDown(self):
         # Clean up the temporary directory
         shutil.rmtree(self.temp_dir)
 
-    async def test_git_log(self):
+    def test_git_log(self):
         """Test the git_log tool."""
-        # Test with no arguments
-        result = await git_log(path=self.temp_dir)
-        self.assertIn("Initial commit", result["output"])
-        self.assertIn("Second commit", result["output"])
 
-        # Test with arguments
-        result = await git_log(arguments="--oneline -n 1", path=self.temp_dir)
-        self.assertIn("Second commit", result["output"])
-        self.assertNotIn("Initial commit", result["output"])
+        async def _test():
+            # Test with no arguments
+            result = await git_log(path=self.temp_dir)
+            self.assertIn("Initial commit", result["output"])
+            self.assertIn("Second commit", result["output"])
 
-    async def test_git_diff(self):
+            # Test with arguments
+            result = await git_log(arguments="--oneline -n 1", path=self.temp_dir)
+            self.assertIn("Second commit", result["output"])
+            self.assertNotIn("Initial commit", result["output"])
+
+        asyncio.run(_test())
+
+    def test_git_diff(self):
         """Test the git_diff tool."""
-        # Create a change but don't commit it
-        with open(self.sample_file, "a") as f:
-            f.write("Uncommitted change\n")
 
-        # Test with no arguments
-        result = await git_diff(path=self.temp_dir)
-        self.assertIn("Uncommitted change", result["output"])
+        async def _test():
+            # Create a change but don't commit it
+            with open(self.sample_file, "a") as f:
+                f.write("Uncommitted change\n")
 
-        # Test with arguments
-        result = await git_diff(arguments="HEAD~1 HEAD", path=self.temp_dir)
-        self.assertIn("Line 4", result["output"])
+            # Test with no arguments
+            result = await git_diff(path=self.temp_dir)
+            self.assertIn("Uncommitted change", result["output"])
 
-    async def test_git_show(self):
+            # Test with arguments
+            result = await git_diff(arguments="HEAD~1 HEAD", path=self.temp_dir)
+            self.assertIn("Line 4", result["output"])
+
+        asyncio.run(_test())
+
+    def test_git_show(self):
         """Test the git_show tool."""
-        # Test with no arguments (should show the latest commit)
-        result = await git_show(path=self.temp_dir)
-        self.assertIn("Second commit", result["output"])
 
-        # Test with arguments
-        result = await git_show(arguments="HEAD~1", path=self.temp_dir)
-        self.assertIn("Initial commit", result["output"])
+        async def _test():
+            # Test with no arguments (should show the latest commit)
+            result = await git_show(path=self.temp_dir)
+            self.assertIn("Second commit", result["output"])
 
-    async def test_git_blame(self):
+            # Test with arguments
+            result = await git_show(arguments="HEAD~1", path=self.temp_dir)
+            self.assertIn("Initial commit", result["output"])
+
+        asyncio.run(_test())
+
+    def test_git_blame(self):
         """Test the git_blame tool."""
-        # Test with file argument
-        result = await git_blame(arguments="sample.txt", path=self.temp_dir)
-        self.assertIn("Test User", result["output"])
-        self.assertIn("Line 2", result["output"])
 
-        # Test with line range
-        result = await git_blame(arguments="-L 4,5 sample.txt", path=self.temp_dir)
-        self.assertIn("Line 4", result["output"])
-        self.assertNotIn("Line 2", result["output"])
+        async def _test():
+            # Test with file argument
+            result = await git_blame(arguments="sample.txt", path=self.temp_dir)
+            self.assertIn("Test User", result["output"])
+            self.assertIn("Line 2", result["output"])
 
-    async def test_invalid_path(self):
+            # Test with line range
+            result = await git_blame(arguments="-L 4,5 sample.txt", path=self.temp_dir)
+            self.assertIn("Line 4", result["output"])
+            self.assertNotIn("Line 2", result["output"])
+
+        asyncio.run(_test())
+
+    def test_invalid_path(self):
         """Test that tools handle invalid paths."""
-        with mock.patch("codemcp.git.is_git_repository", return_value=False):
-            with self.assertRaises(ValueError):
-                await git_log(path="/invalid/path")
 
-            with self.assertRaises(ValueError):
-                await git_diff(path="/invalid/path")
+        async def _test():
+            with mock.patch(
+                "codemcp.tools.git_log.is_git_repository", return_value=False
+            ):
+                with self.assertRaises(ValueError):
+                    await git_log(path="/invalid/path")
 
-            with self.assertRaises(ValueError):
-                await git_show(path="/invalid/path")
+            with mock.patch(
+                "codemcp.tools.git_diff.is_git_repository", return_value=False
+            ):
+                with self.assertRaises(ValueError):
+                    await git_diff(path="/invalid/path")
 
-            with self.assertRaises(ValueError):
-                await git_blame(path="/invalid/path")
+            with mock.patch(
+                "codemcp.tools.git_show.is_git_repository", return_value=False
+            ):
+                with self.assertRaises(ValueError):
+                    await git_show(path="/invalid/path")
 
-    async def test_command_failure(self):
+            with mock.patch(
+                "codemcp.tools.git_blame.is_git_repository", return_value=False
+            ):
+                with self.assertRaises(ValueError):
+                    await git_blame(path="/invalid/path")
+
+        asyncio.run(_test())
+
+    def test_command_failure(self):
         """Test that tools handle command failures."""
-        # Test with invalid arguments
-        result = await git_log(arguments="--invalid-option", path=self.temp_dir)
-        self.assertIn("Error", result["resultForAssistant"])
 
-        result = await git_diff(arguments="--invalid-option", path=self.temp_dir)
-        self.assertIn("Error", result["resultForAssistant"])
+        async def _test():
+            # Test with invalid arguments
+            result = await git_log(arguments="--invalid-option", path=self.temp_dir)
+            self.assertIn("Error", result["resultForAssistant"])
 
-        result = await git_show(arguments="--invalid-option", path=self.temp_dir)
-        self.assertIn("Error", result["resultForAssistant"])
+            result = await git_diff(arguments="--invalid-option", path=self.temp_dir)
+            self.assertIn("Error", result["resultForAssistant"])
 
-        result = await git_blame(arguments="--invalid-option", path=self.temp_dir)
-        self.assertIn("Error", result["resultForAssistant"])
+            result = await git_show(arguments="--invalid-option", path=self.temp_dir)
+            self.assertIn("Error", result["resultForAssistant"])
+
+            result = await git_blame(arguments="--invalid-option", path=self.temp_dir)
+            self.assertIn("Error", result["resultForAssistant"])
+
+        asyncio.run(_test())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #200
* __->__ #196

Fix these pytest warnings.

```git-revs
e57db7c  (Base revision)
4e3d96d  Remove @pytest.mark.asyncio decorator and convert asyncSetUp to sync setUp
2959325  Add asyncio import
31c6249  Implement setUp_async method using asyncio.run
ae6b763  Convert asyncTearDown to standard tearDown
6093c63  Fix async_setup to include git init command
2b14e4b  Convert test_git_log to use asyncio.run with inner async function
fe9708f  Convert test_git_diff to use asyncio.run with inner async function
a83cf90  Convert test_git_show to use asyncio.run with inner async function
ceac4c3  Convert test_git_blame to use asyncio.run with inner async function
f177a40  Convert test_invalid_path to use asyncio.run with inner async function
65d5b29  Convert test_command_failure to use asyncio.run with inner async function
60d29cd  Fix mocking in test_invalid_path to use correct import paths
5bce016  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 206-fix-resolve-pytest-warnings-in-test-git-tools-py