### PR TITLE
feat: serialize non-string content with json.dumps

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import logging
 import os
 
@@ -173,7 +174,12 @@ async def codemcp(
             if description is None:
                 raise ValueError("description is required for WriteFile subtool")
 
-            content_str = content or ""
+            # If content is not a string, serialize it to a string using json.dumps
+            if content is not None and not isinstance(content, str):
+                content_str = json.dumps(content)
+            else:
+                content_str = content or ""
+
             return await write_file_content(path, content_str, description, chat_id)
 
         if subtool == "EditFile":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

When the content parameter to codemcp in codemcp/main.py is not a string, instead of rejecting it, let's serialize it to a string using json.dumps and then proceed. Add a test for this with WriteFile.

```git-revs
5ca0f3c  (Base revision)
fe0cb53  Add json import for serializing non-string content
e1eb78a  Add serialization of non-string content using json.dumps
295b775  Add json import for testing non-string content serialization
80c9601  Add test_write_non_string_content method to test JSON serialization of non-string content
HEAD     Auto-commit format changes
```

codemcp-id: 0-feat-serialize-non-string-content-with-json-dumps