### PR TITLE
feat: serialize non-string content using json.dumps

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -28,7 +28,7 @@ async def codemcp(
     subtool: str,
     *,
     path: str | None = None,
-    content: str | None = None,
+    content: object = None,  # Allow any type, will be serialized to string if needed
     old_string: str | None = None,
     new_string: str | None = None,
     offset: int | None = None,
@@ -178,7 +178,14 @@ async def codemcp(
             if description is None:
                 raise ValueError("description is required for WriteFile subtool")
 
-            content_str = content or ""
+            import json
+
+            # If content is not a string, serialize it to a string using json.dumps
+            if content is not None and not isinstance(content, str):
+                content_str = json.dumps(content)
+            else:
+                content_str = content or ""
+
             return await write_file_content(path, content_str, description, chat_id)
 
         if subtool == "EditFile":

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -473,7 +473,7 @@ Example:
 Args:
     subtool: The subtool to execute (ReadFile, WriteFile, EditFile, LS, InitProject, UserPrompt, RunCommand, RM, Think, Chmod)
     path: The path to the file or directory to operate on
-    content: Content for WriteFile subtool
+    content: Content for WriteFile subtool (any type will be serialized to string if needed)
     old_string: String to replace for EditFile subtool
     new_string: Replacement string for EditFile subtool
     offset: Line offset for ReadFile subtool

--- a/e2e/test_failure_script.py
+++ b/e2e/test_failure_script.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+"""Script to verify that our test fails before applying the code change."""
+
+import os
+import subprocess
+import sys
+
+# Path to the main.py file to be modified
+MAIN_PY_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "codemcp", "main.py"
+)
+
+# Original code snippet that needs to be restored
+ORIGINAL_CODE = """            content_str = content or ""
+            return await write_file_content(path, content_str, description, chat_id)"""
+
+# Modified code with JSON serialization
+MODIFIED_CODE = """            import json
+            
+            # If content is not a string, serialize it to a string using json.dumps
+            if content is not None and not isinstance(content, str):
+                content_str = json.dumps(content)
+            else:
+                content_str = content or ""
+                
+            return await write_file_content(path, content_str, description, chat_id)"""
+
+
+def restore_original_code():
+    """Restore the original code without JSON serialization."""
+    with open(MAIN_PY_PATH, "r") as f:
+        content = f.read()
+
+    # Replace the modified code with the original
+    content = content.replace(MODIFIED_CODE, ORIGINAL_CODE)
+
+    with open(MAIN_PY_PATH, "w") as f:
+        f.write(content)
+
+
+def run_test():
+    """Run the test and return the exit code."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "e2e/test_json_content_serialization.py",
+            "-v",
+        ],
+        capture_output=True,
+    )
+    return result
+
+
+def main():
+    # First, restore the original code
+    restore_original_code()
+    print("Original code restored.")
+
+    # Run the test with original code (should fail)
+    print("Running test with original code (expecting failure)...")
+    result1 = run_test()
+
+    # Print the output
+    print("\nTest output with original code:")
+    print(result1.stdout.decode())
+    print(result1.stderr.decode())
+
+    print(
+        f"Test with original code {'FAILED' if result1.returncode != 0 else 'PASSED'}"
+    )
+    print(f"Return code: {result1.returncode}")
+
+    return result1.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/test_json_content_serialization.py
+++ b/e2e/test_json_content_serialization.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+"""Tests for serializing non-string content using json.dumps."""
+
+import json
+import os
+import unittest
+
+from codemcp.testing import MCPEndToEndTestCase
+
+
+class JsonContentSerializationTest(MCPEndToEndTestCase):
+    """Test the serialization of non-string content for WriteFile subtool."""
+
+    # Set in_process = False to ensure argument validation logic is triggered
+    in_process = False
+
+    async def test_json_serialization(self):
+        """Test that non-string content is properly serialized to JSON."""
+        test_file_path = os.path.join(self.temp_dir.name, "json_serialized.txt")
+
+        # Dictionary to be serialized
+        content_dict = {
+            "name": "Test Object",
+            "values": [1, 2, 3],
+            "nested": {"key": "value", "boolean": True},
+        }
+
+        # Expected serialized string for verification
+        expected_content = json.dumps(content_dict)
+
+        async with self.create_client_session() as session:
+            # First initialize project to get chat_id
+            init_result_text = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "InitProject",
+                    "path": self.temp_dir.name,
+                    "user_prompt": "Test initialization for JSON serialization test",
+                    "subject_line": "test: test json content serialization",
+                    "reuse_head_chat_id": False,
+                },
+            )
+
+            # Extract chat_id from the init result
+            chat_id = self.extract_chat_id_from_text(init_result_text)
+
+            # Call the WriteFile tool with a dict as content
+            result_text = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "WriteFile",
+                    "path": test_file_path,
+                    "content": content_dict,  # Passing a dictionary instead of a string
+                    "description": "Create file with JSON serialized content",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Verify the success message
+            self.assertIn("Successfully wrote to", result_text)
+
+            # Verify the file was created with the correct content
+            with open(test_file_path) as f:
+                file_content = f.read()
+
+            self.assertEqual(file_content, expected_content)
+
+            # Test with a list
+            content_list = [1, "two", 3.0, False, None]
+            expected_list_content = json.dumps(content_list)
+            list_file_path = os.path.join(self.temp_dir.name, "list_serialized.txt")
+
+            # Call WriteFile with a list as content
+            result_text = await self.call_tool_assert_success(
+                session,
+                "codemcp",
+                {
+                    "subtool": "WriteFile",
+                    "path": list_file_path,
+                    "content": content_list,  # Passing a list instead of a string
+                    "description": "Create file with list content",
+                    "chat_id": chat_id,
+                },
+            )
+
+            # Verify the success message
+            self.assertIn("Successfully wrote to", result_text)
+
+            # Verify the file was created with the correct content
+            with open(list_file_path) as f:
+                file_content = f.read()
+
+            self.assertEqual(file_content, expected_list_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/restore_original.py
+++ b/restore_original.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+"""Script to restore the original code in main.py."""
+
+import os
+
+# Path to the main.py file
+MAIN_PY_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "codemcp", "main.py"
+)
+
+# Original code snippet
+ORIGINAL_CODE = """            content_str = content or ""
+            return await write_file_content(path, content_str, description, chat_id)"""
+
+# Modified code with JSON serialization
+MODIFIED_CODE = """            import json
+            
+            # If content is not a string, serialize it to a string using json.dumps
+            if content is not None and not isinstance(content, str):
+                content_str = json.dumps(content)
+            else:
+                content_str = content or ""
+                
+            return await write_file_content(path, content_str, description, chat_id)"""
+
+
+def restore_original_code():
+    """Restore the original code without JSON serialization."""
+    with open(MAIN_PY_PATH, "r") as f:
+        content = f.read()
+
+    # Replace the modified code with the original
+    content = content.replace(MODIFIED_CODE, ORIGINAL_CODE)
+
+    with open(MAIN_PY_PATH, "w") as f:
+        f.write(content)
+
+    print(f"Original code restored in {MAIN_PY_PATH}")
+
+
+if __name__ == "__main__":
+    restore_original_code()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #202

When the content parameter to codemcp in codemcp/main.py is not a string, instead of rejecting it, let's serialize it to a string using json.dumps and then proceed. Add a test for this with WriteFile; note that to trigger argument validation logic, you MUST set in_process = False on the test class, make a dedicated test class for this test, and verify that your test fails without your code change.

```git-revs
440a7e7  (Base revision)
a1d8db6  Serialize non-string content using json.dumps for WriteFile subtool
d732993  Add test for serializing non-string content to JSON
0f487bb  Add script to test failure without our code change
8225c05  Add script to restore original code
3babc32  Change content parameter type to accept any object
84cfe83  Update content parameter description in init_project.py
e57f442  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 0-feat-serialize-non-string-content-using-json-dumps