### PR TITLE
feat: add Click CLI with init subcommand

### DIFF
--- a/codemcp/__init__.py
+++ b/codemcp/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from .hot_reload_entry import run as run_hot_reload
-from .main import codemcp, configure_logging, mcp, run
+from .main import cli, codemcp, configure_logging, mcp, run
 from .shell import get_subprocess_env, run_command
 
 __all__ = [
@@ -12,4 +12,5 @@ __all__ = [
     "codemcp",
     "run_command",
     "get_subprocess_env",
+    "cli",
 ]

--- a/codemcp/__main__.py
+++ b/codemcp/__main__.py
@@ -2,9 +2,10 @@
 
 # WARNING: do NOT do a relative import, this file must be directly executable
 # by filename
-from codemcp import mcp, run
+from codemcp import cli, mcp
 
 __all__ = ["mcp"]
 
 if __name__ == "__main__":
-    run()
+    # Use Click's CLI interface instead of directly calling run()
+    cli()

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -412,22 +412,22 @@ def configure_logging(log_file="codemcp.log"):
 
 def init_codemcp_project(path: str) -> str:
     """Initialize a new codemcp project.
-    
+
     Args:
         path: Path to initialize the project in
-    
+
     Returns:
         Message indicating success or failure
     """
     import subprocess
-    
+
     try:
         # Convert to Path object and resolve to absolute path
         project_path = Path(path).resolve()
-        
+
         # Create directory if it doesn't exist
         project_path.mkdir(parents=True, exist_ok=True)
-        
+
         # Check if git repository already exists
         git_dir = project_path / ".git"
         if not git_dir.exists():
@@ -436,7 +436,7 @@ def init_codemcp_project(path: str) -> str:
             print(f"Initialized git repository in {project_path}")
         else:
             print(f"Git repository already exists in {project_path}")
-        
+
         # Create empty codemcp.toml file if it doesn't exist
         config_file = project_path / "codemcp.toml"
         if not config_file.exists():
@@ -445,18 +445,18 @@ def init_codemcp_project(path: str) -> str:
             print(f"Created empty codemcp.toml file in {project_path}")
         else:
             print(f"codemcp.toml file already exists in {project_path}")
-        
+
         # Make initial commit if there are no commits yet
         try:
             # Check if there are any commits
             result = subprocess.run(
-                ["git", "rev-parse", "HEAD"], 
-                cwd=project_path, 
+                ["git", "rev-parse", "HEAD"],
+                cwd=project_path,
                 check=False,
                 capture_output=True,
                 text=True,
             )
-            
+
             if result.returncode != 0:
                 # No commits yet, add codemcp.toml and make initial commit
                 subprocess.run(
@@ -472,7 +472,7 @@ def init_codemcp_project(path: str) -> str:
                 print("Repository already has commits, not creating initial commit")
         except subprocess.CalledProcessError as e:
             print(f"Warning: Failed to create initial commit: {e}")
-        
+
         return f"Successfully initialized codemcp project in {project_path}"
     except Exception as e:
         return f"Error initializing project: {e}"

--- a/e2e/test_init_command.py
+++ b/e2e/test_init_command.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from codemcp.main import init_codemcp_project
+
+
+def test_init_command():
+    """Test the init command creates a codemcp.toml file and initializes a git repo."""
+    # Create a temporary directory for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Run the init_codemcp_project function
+        result = init_codemcp_project(temp_dir)
+
+        # Check that the function reports success
+        assert "Successfully initialized" in result
+
+        # Check that codemcp.toml was created
+        config_file = Path(temp_dir) / "codemcp.toml"
+        assert config_file.exists()
+
+        # Check that git repository was initialized
+        git_dir = Path(temp_dir) / ".git"
+        assert git_dir.is_dir()
+
+        # Check that a commit was created
+        result = subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=temp_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "initialize codemcp project" in result.stdout
+
+
+def test_init_command_existing_repo():
+    """Test the init command works with an existing git repository."""
+    # Create a temporary directory for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Initialize git repository first
+        subprocess.run(["git", "init"], cwd=temp_dir, check=True)
+
+        # Make a dummy commit to simulate existing repository
+        dummy_file = Path(temp_dir) / "dummy.txt"
+        dummy_file.write_text("test content")
+
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"], cwd=temp_dir, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=temp_dir,
+            check=True,
+        )
+        subprocess.run(["git", "add", "dummy.txt"], cwd=temp_dir, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], cwd=temp_dir, check=True
+        )
+
+        # Run the init_codemcp_project function
+        result = init_codemcp_project(temp_dir)
+
+        # Check that the function reports success
+        assert "Successfully initialized" in result
+
+        # Check that codemcp.toml was created
+        config_file = Path(temp_dir) / "codemcp.toml"
+        assert config_file.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyyaml>=6.0.0",
     "pytest-xdist>=3.6.1",
     "editorconfig>=0.17.0",
+    "click>=8.1.8",
 ]
 
 [dependency-groups]
@@ -28,7 +29,7 @@ dev = [
 ]
 
 [project.scripts]
-codemcp = "codemcp:run"
+codemcp = "codemcp:cli"
 codemcp-multi = "codemcp.multi_entry:main"
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -76,6 +76,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
+    { name = "click" },
     { name = "editorconfig" },
     { name = "mcp", extra = ["cli"] },
     { name = "pytest-xdist" },
@@ -99,6 +100,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=3.7.0" },
+    { name = "click", specifier = ">=8.1.8" },
     { name = "editorconfig", specifier = ">=0.17.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #209
* #208
* #207
* #205
* __->__ #203

Let's use click to make codemcp a generic command line tool as well as MCP. For BC it should still launch the MCP server with no arguments but we will also add an 'init' subcommand that creates an empty codemcp.toml, init's a git repository, and makes an initial commit with these files.

```git-revs
5c3e88d  (Base revision)
1d06d21  Add Click import and other imports needed for CLI
1155f1a  Add init_codemcp_project function and Click CLI
670b226  Export CLI function from __init__.py
1842a58  Update __main__.py to use Click CLI
14d2d2c  Snapshot before codemcp change
f70e670  Update pyproject.toml to use cli function
af997d8  Add end-to-end test for init command
8302b2b  Snapshot before auto-format
1d91f4e  Auto-commit format changes
11bc401  Auto-commit lint changes
HEAD     Move subprocess import to the top of the init_codemcp_project function
```

codemcp-id: 209-feat-add-click-cli-with-init-subcommand