### PR TITLE
refactor: use tool names and descriptions as source of truth

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -2,9 +2,7 @@
 
 import logging
 import os
-import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 from mcp.server.fastmcp import FastMCP

--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -24,7 +24,62 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "edit_file_content",
     "find_similar_file",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "EditFile"
+DESCRIPTION = """
+This is a tool for editing files. For larger edits, use the Write tool to overwrite files.
+Provide a short description of the change.
+
+Before using this tool:
+
+1. Use the View tool to understand the file's contents and context
+
+2. Verify the directory path is correct (only applicable when creating new files):
+   - Use the LS tool to verify the parent directory exists and is the correct location
+
+To make a file edit, provide the following:
+1. path: The absolute path to the file to modify (must be absolute, not relative)
+2. old_string: The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace and indentation)
+3. new_string: The edited text to replace the old_string
+
+The tool will replace ONE occurrence of old_string with new_string in the specified file.
+
+CRITICAL REQUIREMENTS FOR USING THIS TOOL:
+
+1. UNIQUENESS: The old_string MUST uniquely identify the specific instance you want to change. This means:
+   - Include AT LEAST 3-5 lines of context BEFORE the change point
+   - Include AT LEAST 3-5 lines of context AFTER the change point
+   - Include all whitespace, indentation, and surrounding code exactly as it appears in the file
+
+2. SINGLE INSTANCE: This tool can only change ONE instance at a time. If you need to change multiple instances:
+   - Make separate calls to this tool for each instance
+   - Each call must uniquely identify its specific instance using extensive context
+
+3. VERIFICATION: Before using this tool:
+   - Check how many instances of the target text exist in the file
+   - If multiple instances exist, gather enough context to uniquely identify each one
+   - Plan separate tool calls for each instance
+
+WARNING: If you do not follow these requirements:
+   - The tool will fail if old_string matches multiple locations
+   - The tool will fail if old_string doesn't match exactly (including whitespace)
+   - You may change the wrong instance if you don't include enough context
+
+When making edits:
+   - Ensure the edit results in idiomatic, correct code
+   - Do not leave the code in a broken state
+   - Always use absolute file paths (starting with /)
+
+If you want to create a new file, use:
+   - A new file path, including dir name if needed
+   - An empty old_string
+   - The new file's contents as new_string
+
+Remember: when making multiple file edits in a row to the same file, you should prefer to send all edits in a single message with multiple calls to this tool, rather than multiple messages with a single call each.
+"""
 
 
 def find_similar_file(file_path: str) -> str | None:

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -13,7 +13,17 @@ __all__ = [
     "glob_files",
     "glob",
     "render_result_for_assistant",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "Glob"
+DESCRIPTION = """
+Fast file pattern matching tool that works with any codebase size
+Supports glob patterns like "**/*.js" or "src/**/*.ts"
+Returns matching file paths sorted by modification time
+Use this tool when you need to find files by name patterns
+"""
 
 # Define constants
 MAX_RESULTS = 100

--- a/codemcp/tools/ls.py
+++ b/codemcp/tools/ls.py
@@ -15,7 +15,14 @@ __all__ = [
     "create_file_tree",
     "print_tree",
     "MAX_FILES",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "LS"
+DESCRIPTION = """
+Lists files and directories in a given path. The path parameter must be an absolute path, not a relative path. You should generally prefer the Glob and Grep tools, if you know which directories to search.
+"""
 
 MAX_FILES = 1000
 TRUNCATED_MESSAGE = f"There are more than {MAX_FILES} files in the directory. Use more specific paths to explore nested directories. The first {MAX_FILES} files and directories are included below:\n\n"

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -13,7 +13,14 @@ from ..rules import get_applicable_rules_content
 
 __all__ = [
     "read_file_content",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "ReadFile"
+DESCRIPTION = """
+Reads a file from the local filesystem. The path parameter must be an absolute path, not a relative path. By default, it reads up to {MAX_LINES_TO_READ} lines starting from the beginning of the file. You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters. Any lines longer than {MAX_LINE_LENGTH} characters will be truncated. For image files, the tool will display the image for you.
+"""
 
 
 async def read_file_content(

--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -10,7 +10,24 @@ from ..shell import run_command
 
 __all__ = [
     "rm_file",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "RM"
+DESCRIPTION = """
+Removes a file using git rm and commits the change.
+Provide a short description of why the file is being removed.
+
+Before using this tool:
+1. Ensure the file exists and is tracked by git
+2. Provide a meaningful description of why the file is being removed
+
+Args:
+    path: The path to the file to remove (can be relative to the project root or absolute)
+    description: Short description of why the file is being removed
+    chat_id: The unique ID to identify the chat session
+"""
 
 
 async def rm_file(

--- a/codemcp/tools/run_command.py
+++ b/codemcp/tools/run_command.py
@@ -7,7 +7,23 @@ from ..code_command import get_command_from_config, run_code_command
 
 __all__ = [
     "run_command",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "RunCommand"
+DESCRIPTION = """
+Runs a command.  This does NOT support arbitrary code execution, ONLY call
+with this set of valid commands: format, lint, ghstack, test, accept
+The arguments parameter should be a string and will be interpreted as space-separated
+arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+for arguments containing spaces, etc.).
+
+
+Command documentation:
+- test: Accepts a pytest-style test selector as an argument to run a specific test.
+- accept: Updates expecttest failing tests with their new values, akin to running with EXPECTTEST_ACCEPT=1. Accepts a pytest-style test selector as an argument to run a specific test.
+"""
 
 
 async def run_command(

--- a/codemcp/tools/think.py
+++ b/codemcp/tools/think.py
@@ -4,7 +4,14 @@ import logging
 
 __all__ = [
     "think",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "Think"
+DESCRIPTION = """
+Use the tool to think about something. It will not obtain new information or change the database, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.
+"""
 
 
 async def think(thought: str, chat_id: str | None = None) -> str:

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -8,7 +8,16 @@ from ..rules import get_applicable_rules_content
 
 __all__ = [
     "user_prompt",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "UserPrompt"
+DESCRIPTION = """
+Records the user's verbatim prompt text for each interaction after the initial one.
+You should call this tool with the user's exact message at the beginning of each response.
+This tool must be called in every response except for the first one where InitProject was used.  Do NOT include documents or other attachments, only the text prompt.
+"""
 
 
 async def user_prompt(user_text: str, chat_id: str | None = None) -> str:

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -12,7 +12,22 @@ from ..line_endings import detect_line_endings, detect_repo_line_endings
 
 __all__ = [
     "write_file_content",
+    "TOOL_NAME_FOR_PROMPT",
+    "DESCRIPTION",
 ]
+
+TOOL_NAME_FOR_PROMPT = "WriteFile"
+DESCRIPTION = """
+Write a file to the local filesystem. Overwrites the existing file if there is one.
+Provide a short description of the change.
+
+Before using this tool:
+
+1. Use the ReadFile tool to understand the file's contents and context
+
+2. Directory Verification (only applicable when creating new files):
+   - Use the LS tool to verify the parent directory exists and is the correct location
+"""
 
 
 async def write_file_content(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Some of our tools have TOOL_NAME_FOR_PROMPT and DESCRIPTION but they don't do anything right now. Refactor init_project.py to collect and use these as source of truth, and introduce these for all other tools.

```git-revs
b9c2d48  (Base revision)
fe38426  Adding imports and new function to __all__
e62b085  Adding collect_tool_descriptions function
35a1c5f  Adding the collect_tool_descriptions call
ff64edc  Fixing duplication and preparing for system prompt construction
b4792b2  Adding tool documentation generation logic
5836e37  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to read_file.py
9443e12  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to write_file.py
d31da24  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to edit_file.py
29a4fef  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to ls.py
b7f1bfe  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to think.py
0d17e96  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to glob.py
7587856  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to user_prompt.py
28844fa  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to rm.py
8755cfd  Adding TOOL_NAME_FOR_PROMPT and DESCRIPTION constants to run_command.py
948dac2  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 210-refactor-use-tool-names-and-descriptions-as-source