### PR TITLE
refactor: remove execution_time from tool reporting

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -2,9 +2,7 @@
 
 import logging
 import os
-import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 from mcp.server.fastmcp import FastMCP

--- a/codemcp/tools/chmod.py
+++ b/codemcp/tools/chmod.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import stat
-import time
 from typing import Any, Literal
 
 from ..common import normalize_file_path
@@ -44,10 +43,8 @@ async def chmod(
         signal: Optional abort signal to terminate the subprocess
 
     Returns:
-        A dictionary with execution stats and chmod output
+        A dictionary with chmod output
     """
-    start_time = time.time()
-
     if not path:
         raise ValueError("File path must be provided")
 
@@ -76,14 +73,12 @@ async def chmod(
             message = f"File '{path}' is already executable"
             return {
                 "output": message,
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": message,
             }
         elif mode == "a-x" and not is_executable:
             message = f"File '{path}' is already non-executable"
             return {
                 "output": message,
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": message,
             }
 
@@ -118,19 +113,12 @@ async def chmod(
             logging.warning(f"Failed to commit chmod changes: {commit_message}")
             return {
                 "output": f"{action_msg}, but failed to commit changes: {commit_message}",
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": f"{action_msg}, but failed to commit changes: {commit_message}",
             }
-
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000
-        )  # Convert to milliseconds
 
         # Prepare output
         output = {
             "output": f"{action_msg} and committed changes",
-            "durationMs": execution_time,
         }
 
         # Add formatted result for assistant
@@ -142,7 +130,6 @@ async def chmod(
         error_message = f"Error executing chmod: {e!s}"
         return {
             "output": error_message,
-            "durationMs": int((time.time() - start_time) * 1000),
             "resultForAssistant": error_message,
         }
 

--- a/codemcp/tools/git_blame.py
+++ b/codemcp/tools/git_blame.py
@@ -2,7 +2,6 @@
 
 import logging
 import shlex
-import time
 from typing import Any
 
 from ..common import normalize_file_path
@@ -46,9 +45,8 @@ async def git_blame(
         signal: Optional abort signal to terminate the subprocess
 
     Returns:
-        A dictionary with execution stats and git blame output
+        A dictionary with git blame output
     """
-    start_time = time.time()
 
     if path is None:
         raise ValueError("Path must be provided for git blame")
@@ -88,19 +86,12 @@ async def git_blame(
             error_message = f"Error: {result.stderr}"
             return {
                 "output": error_message,
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": error_message,
             }
-
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000
-        )  # Convert to milliseconds
 
         # Prepare output
         output = {
             "output": result.stdout,
-            "durationMs": execution_time,
         }
 
         # Add formatted result for assistant
@@ -112,7 +103,6 @@ async def git_blame(
         error_message = f"Error executing git blame: {e!s}"
         return {
             "output": error_message,
-            "durationMs": int((time.time() - start_time) * 1000),
             "resultForAssistant": error_message,
         }
 

--- a/codemcp/tools/git_diff.py
+++ b/codemcp/tools/git_diff.py
@@ -2,7 +2,6 @@
 
 import logging
 import shlex
-import time
 from typing import Any
 
 from ..common import normalize_file_path
@@ -47,9 +46,8 @@ async def git_diff(
         signal: Optional abort signal to terminate the subprocess
 
     Returns:
-        A dictionary with execution stats and git diff output
+        A dictionary with git diff output
     """
-    start_time = time.time()
 
     if path is None:
         raise ValueError("Path must be provided for git diff")
@@ -89,19 +87,12 @@ async def git_diff(
             error_message = f"Error: {result.stderr}"
             return {
                 "output": error_message,
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": error_message,
             }
-
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000
-        )  # Convert to milliseconds
 
         # Prepare output
         output = {
             "output": result.stdout,
-            "durationMs": execution_time,
         }
 
         # Add formatted result for assistant
@@ -113,7 +104,6 @@ async def git_diff(
         error_message = f"Error executing git diff: {e!s}"
         return {
             "output": error_message,
-            "durationMs": int((time.time() - start_time) * 1000),
             "resultForAssistant": error_message,
         }
 

--- a/codemcp/tools/git_log.py
+++ b/codemcp/tools/git_log.py
@@ -2,7 +2,6 @@
 
 import logging
 import shlex
-import time
 from typing import Any
 
 from ..common import normalize_file_path
@@ -46,9 +45,8 @@ async def git_log(
         signal: Optional abort signal to terminate the subprocess
 
     Returns:
-        A dictionary with execution stats and git log output
+        A dictionary with git log output
     """
-    start_time = time.time()
 
     if path is None:
         raise ValueError("Path must be provided for git log")
@@ -88,19 +86,12 @@ async def git_log(
             error_message = f"Error: {result.stderr}"
             return {
                 "output": error_message,
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": error_message,
             }
-
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000
-        )  # Convert to milliseconds
 
         # Prepare output
         output = {
             "output": result.stdout,
-            "durationMs": execution_time,
         }
 
         # Add formatted result for assistant
@@ -112,7 +103,6 @@ async def git_log(
         error_message = f"Error executing git log: {e!s}"
         return {
             "output": error_message,
-            "durationMs": int((time.time() - start_time) * 1000),
             "resultForAssistant": error_message,
         }
 

--- a/codemcp/tools/git_show.py
+++ b/codemcp/tools/git_show.py
@@ -2,7 +2,6 @@
 
 import logging
 import shlex
-import time
 from typing import Any
 
 from ..common import normalize_file_path
@@ -48,9 +47,8 @@ async def git_show(
         signal: Optional abort signal to terminate the subprocess
 
     Returns:
-        A dictionary with execution stats and git show output
+        A dictionary with git show output
     """
-    start_time = time.time()
 
     if path is None:
         raise ValueError("Path must be provided for git show")
@@ -90,19 +88,12 @@ async def git_show(
             error_message = f"Error: {result.stderr}"
             return {
                 "output": error_message,
-                "durationMs": int((time.time() - start_time) * 1000),
                 "resultForAssistant": error_message,
             }
-
-        # Calculate execution time
-        execution_time = int(
-            (time.time() - start_time) * 1000
-        )  # Convert to milliseconds
 
         # Prepare output
         output = {
             "output": result.stdout,
-            "durationMs": execution_time,
         }
 
         # Add formatted result for assistant
@@ -114,7 +105,6 @@ async def git_show(
         error_message = f"Error executing git show: {e!s}"
         return {
             "output": error_message,
-            "durationMs": int((time.time() - start_time) * 1000),
             "resultForAssistant": error_message,
         }
 

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import os
-import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -169,10 +168,8 @@ async def glob_files(
         signal: Optional abort signal to terminate the operation
 
     Returns:
-        A dictionary with execution stats and matched files
+        A dictionary with matched files
     """
-    start_time = time.time()
-
     # Use current working directory if path is not provided
     if path is None:
         path = os.getcwd()
@@ -186,16 +183,12 @@ async def glob_files(
     # Execute glob
     result = await glob(pattern, path, options, signal)
 
-    # Calculate execution time
-    execution_time = int((time.time() - start_time) * 1000)  # Convert to milliseconds
-
     # Get matching files
     files = result.get("files", [])
 
     # Prepare output
     output = {
         "filenames": files,
-        "durationMs": execution_time,
         "numFiles": len(files),
         "truncated": result.get("truncated", False),
     }

--- a/codemcp/tools/grep.py
+++ b/codemcp/tools/grep.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import subprocess
-import time
 from typing import Any
 
 from ..common import normalize_file_path
@@ -173,10 +172,9 @@ async def grep_files(
         signal: Optional abort signal to terminate the subprocess
 
     Returns:
-        A dictionary with execution stats and matched files
+        A dictionary with matched files
 
     """
-    start_time = time.time()
 
     # Execute git grep asynchronously
     matches = await git_grep(pattern, path, include, signal)
@@ -215,15 +213,9 @@ async def grep_files(
         )
         matches.sort()
 
-    # Calculate execution time
-    execution_time = int(
-        (time.time() - start_time) * 1000,
-    )  # Convert to milliseconds
-
     # Prepare output
     output = {
         "filenames": matches[:MAX_RESULTS],
-        "durationMs": execution_time,
         "numFiles": len(matches),
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #209
* #208
* #207
* __->__ #205
* #203

Some tools report execution time (execution_time). This is pointless, remove it from all of them.

```git-revs
74289f5  (Base revision)
9c5623b  Remove execution_time calculation and durationMs from glob_files output
3ea1c75  Remove start_time and execution stats related code from chmod function docstring and start
3ceef27  Remove durationMs from chmod early return statements
e5602f6  Remove execution_time calculation and durationMs from chmod output
53df773  Remove durationMs from chmod error handling
30314a0  Remove execution stats mention and start_time from git_log function
aad0e1e  Remove execution_time calculation and durationMs from git_log output
0155b92  Remove durationMs from git_log error handling
5accde2  Remove execution stats mention and start_time from git_blame function
c7686d3  Remove execution_time calculation and durationMs from git_blame output
a47db12  Remove durationMs from git_blame error handling
ea94b86  Remove execution stats mention and start_time from git_diff function
71c0dca  Remove execution_time calculation and durationMs from git_diff output
7ea1010  Remove durationMs from git_diff error handling
f6e301c  Remove execution stats mention and start_time from git_show function
b4553d7  Remove execution_time calculation and durationMs from git_show output
550f606  Remove durationMs from git_show error handling
dafec72  Remove execution stats mention and start_time from grep_files function
8d2a6d0  Remove execution_time calculation and durationMs from grep_files output
HEAD     Auto-commit lint changes
```

codemcp-id: 211-refactor-remove-execution-time-from-tool-reporting