### PR TITLE
fix: typecheck and fix errors in glob.py

### DIFF
--- a/codemcp/glob.py
+++ b/codemcp/glob.py
@@ -30,7 +30,7 @@ def translate_pattern(
     editorconfig_asterisk = editorconfig
     editorconfig_double_asterisk = editorconfig
     i, n = 0, len(pattern)
-    result = []
+    result: List[str] = []
 
     # Handle escaped characters
     escaped = False
@@ -178,7 +178,7 @@ def translate_pattern(
                 else:
                     # Handle comma-separated items {s1,s2,s3}
                     # Split but respect any nested braces
-                    items = []
+                    items: List[str] = []
                     start = 0
                     nested_depth = 0
 
@@ -200,7 +200,7 @@ def translate_pattern(
                         i = i - len(brace_content) - 2
                     else:
                         # Process each item recursively to handle nested braces
-                        processed_items = []
+                        processed_items: List[str] = []
                         for item in items:
                             # For nested patterns, recursively translate but without the anchors
                             if "{" in item:
@@ -324,7 +324,7 @@ def find(
     Returns:
         List of paths that match any of the patterns
     """
-    result = []
+    result: List[str] = []
     matchers = [
         make_matcher(
             pattern,
@@ -341,7 +341,7 @@ def find(
         return result
 
     # Walk filesystem
-    for dirpath, dirnames, filenames in os.walk(root):
+    for dirpath, _, filenames in os.walk(root):
         rel_dirpath = os.path.relpath(dirpath, root)
         if rel_dirpath == ".":
             rel_dirpath = ""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #215
* #214
* #213
* #212
* #211
* __->__ #210
* #209

Typecheck codemcp/glob.py and fix errors. Typecheck ONLY this file (typecheck command takes a filename as argument).

```git-revs
3ffd8f2  (Base revision)
2f6e403  Add missing List[str] type annotation for result variable and import Any from typing
d29a90c  Add List[str] type annotation for items variable
4b4ea7f  Add List[str] type annotation for processed_items variable
3ada72b  Add List[str] type annotation for result variable in find function
164fff5  Replace unused dirnames variable with underscore to avoid warning
HEAD     Remove unused Any import
```

codemcp-id: 218-fix-typecheck-and-fix-errors-in-glob-py