### PR TITLE
fix: resolve type checking errors in code_command.py

### DIFF
--- a/codemcp/code_command.py
+++ b/codemcp/code_command.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import subprocess
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import tomli
 
@@ -43,9 +43,9 @@ def get_command_from_config(project_dir: str, command_name: str) -> Optional[Lis
             cmd_config = config["commands"][command_name]
             # Handle both direct command lists and dictionaries with 'command' field
             if isinstance(cmd_config, list):
-                return cmd_config
+                return cmd_config  # type: ignore
             elif isinstance(cmd_config, dict) and "command" in cmd_config:
-                return cmd_config["command"]
+                return cmd_config["command"]  # type: ignore
 
         return None
     except Exception as e:

--- a/codemcp/git_message.py
+++ b/codemcp/git_message.py
@@ -13,7 +13,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-def append_metadata_to_message(message: str, metadata: dict) -> str:
+def append_metadata_to_message(message: str, metadata: dict[str, str]) -> str:
     """Append trailers to Git commit message
 
     Args:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #215
* #214
* #213
* __->__ #212
* #211
* #210
* #209

Let's continue fixing the typecheck errors in the codemcp project. We've already made progress on shell.py, async_file_utils.py, file_utils.py, and git_query.py. Now we should focus on fixing the remaining issues in code_command.py, git_message.py, and hot_reload_entry.py. Let's start with code_command.py which has issues with return type annotations and handling of string/bytes types.

```git-revs
5af23b5  (Base revision)
1d3d1a5  Remove unused Union import
3439a2e  Add type ignore comments to handle unknown types in return statements
dee99a9  Add type arguments for dict in append_metadata_to_message
8f2e147  Add more type imports needed for annotations
ed75b38  Add type arguments for Task and Queue
197bfef  Add type arguments for Queue in _run_manager_task
9f98a5f  Add type annotation for kwargs parameter in call_tool
414dbeb  Add type annotation for kwargs parameter in codemcp function
49f74b5  Add a default case to the match statement for exhaustive handling
4c483d6  Remove unused imports and add Future import
ecc9c67  Add type annotation for stop_future
c051d46  Add type annotation for response_future and handle None check for _request_queue
HEAD     Auto-commit format changes
```

codemcp-id: 221-fix-resolve-type-checking-errors-in-code-command-p