### PR TITLE
fix: typecheck common.py and fix type errors

### DIFF
--- a/codemcp/common.py
+++ b/codemcp/common.py
@@ -87,7 +87,9 @@ def get_edit_snippet(
     return "\n".join(result)
 
 
-def truncate_output_content(content: Union[str, bytes], prefer_end: bool = True) -> str:
+def truncate_output_content(
+    content: Union[str, bytes, None], prefer_end: bool = True
+) -> str:
     """Truncate command output content to a reasonable size.
 
     When prefer_end is True, this function prioritizes keeping content from the end
@@ -101,8 +103,10 @@ def truncate_output_content(content: Union[str, bytes], prefer_end: bool = True)
     Returns:
         The truncated content with appropriate indicators
     """
+    if content is None:
+        return ""
     if not content:
-        return "" if content is None else str(content)
+        return str(content)
 
     # Convert bytes to str if needed
     if isinstance(content, bytes):

--- a/codemcp/file_utils.py
+++ b/codemcp/file_utils.py
@@ -7,9 +7,9 @@ from typing import Optional, Tuple
 import anyio
 
 from .access import check_edit_permission
+from .async_file_utils import OpenTextMode
 from .git import commit_changes
 from .line_endings import apply_line_endings, normalize_to_lf
-from .async_file_utils import OpenTextMode
 
 __all__ = [
     "check_file_path_and_permissions",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #215
* #214
* __->__ #213
* #212
* #211
* #210
* #209

Typecheck codemcp/common.py and fix errors.

```git-revs
509db66  (Base revision)
9ee1208  Fix type error by adding None to Union type and separating null check
84e8180  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 222-fix-typecheck-common-py-and-fix-type-errors