### PR TITLE
chore: initialize project for configuration file typecheck

### DIFF
--- a/codemcp/config.py
+++ b/codemcp/config.py
@@ -98,7 +98,9 @@ def _merge_configs(base: dict[str, Any], override: dict[str, Any]) -> None:
     """
     for key, value in override.items():
         if key in base and isinstance(base[key], dict) and isinstance(value, dict):
-            _merge_configs(base[key], value)
+            # Type annotation to help the type checker understand that value is dict[str, Any]
+            nested_value: dict[str, Any] = value
+            _merge_configs(base[key], nested_value)
         else:
             base[key] = value
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #215
* __->__ #214
* #213
* #212
* #211
* #210
* #209

typecheck codemcp/config.py

```git-revs
b64ed56  (Base revision)
HEAD     Fix type error by adding explicit type annotation for nested dictionary value
```

codemcp-id: 223-chore-initialize-project-for-configuration-file-ty