### PR TITLE
fix: type checking errors in tools directory

### DIFF
--- a/codemcp/tools/chmod.py
+++ b/codemcp/tools/chmod.py
@@ -31,7 +31,6 @@ async def chmod(
     path: str,
     mode: Literal["a+x", "a-x"],
     chat_id: str | None = None,
-    signal=None,
 ) -> dict[str, Any]:
     """Change file permissions using chmod.
 
@@ -39,7 +38,6 @@ async def chmod(
         path: The absolute path to the file to modify
         mode: The chmod mode to apply, only "a+x" and "a-x" are supported
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A dictionary with chmod output
@@ -104,7 +102,7 @@ async def chmod(
     success, commit_message = await commit_changes(
         directory,
         description,
-        chat_id,
+        chat_id if chat_id is not None else "",
     )
 
     if not success:

--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -7,6 +7,7 @@ import math
 import os
 import re
 from difflib import SequenceMatcher
+from typing import Any
 
 from ..common import get_edit_snippet
 from ..file_utils import (
@@ -53,7 +54,7 @@ async def apply_edit(
     file_path: str,
     old_string: str,
     new_string: str,
-) -> tuple[list[dict], str]:
+) -> tuple[list[dict[str, Any]], str]:
     """Apply an edit to a file using robust matching strategies.
 
     Args:
@@ -322,7 +323,7 @@ def try_dotdotdots(whole: str, part: str, replace: str) -> str | None:
     part_pieces = [part_pieces[i] for i in range(0, len(part_pieces), 2)]
     replace_pieces = [replace_pieces[i] for i in range(0, len(replace_pieces), 2)]
 
-    pairs = zip(part_pieces, replace_pieces, strict=False)
+    pairs = list(zip(part_pieces, replace_pieces))
     for part, replace in pairs:
         if not part and not replace:
             continue
@@ -415,8 +416,13 @@ def find_similar_lines(
     search_lines = search_lines.splitlines()
     content_lines = content_lines.splitlines()
 
+    # Handle empty input cases
+    if not search_lines or not content_lines:
+        return ""
+
     best_ratio = 0
-    best_match = None
+    best_match = []  # Initialize with empty list to avoid None checks
+    best_match_i = 0  # Initialize to avoid unbound variable errors
 
     for i in range(len(content_lines) - len(search_lines) + 1):
         chunk = content_lines[i : i + len(search_lines)]
@@ -730,7 +736,7 @@ async def edit_file_content(
             )
 
     # Apply the edit with advanced matching if needed
-    patch, updated_file = await apply_edit(full_file_path, old_string, new_string)
+    _, updated_file = await apply_edit(full_file_path, old_string, new_string)
 
     # If no changes were made (which should never happen at this point),
     # log a warning but continue

--- a/codemcp/tools/git_blame.py
+++ b/codemcp/tools/git_blame.py
@@ -34,7 +34,6 @@ async def git_blame(
     arguments: str | None = None,
     path: str | None = None,
     chat_id: str | None = None,
-    signal=None,
 ) -> dict[str, Any]:
     """Execute git blame with the provided arguments.
 
@@ -42,7 +41,6 @@ async def git_blame(
         arguments: Optional arguments to pass to git blame as a string
         path: The directory to execute the command in (must be in a git repository)
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A dictionary with git blame output

--- a/codemcp/tools/git_diff.py
+++ b/codemcp/tools/git_diff.py
@@ -35,7 +35,6 @@ async def git_diff(
     arguments: str | None = None,
     path: str | None = None,
     chat_id: str | None = None,
-    signal=None,
 ) -> dict[str, Any]:
     """Execute git diff with the provided arguments.
 
@@ -43,7 +42,6 @@ async def git_diff(
         arguments: Optional arguments to pass to git diff as a string
         path: The directory to execute the command in (must be in a git repository)
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A dictionary with git diff output

--- a/codemcp/tools/git_log.py
+++ b/codemcp/tools/git_log.py
@@ -34,7 +34,6 @@ async def git_log(
     arguments: str | None = None,
     path: str | None = None,
     chat_id: str | None = None,
-    signal=None,
 ) -> dict[str, Any]:
     """Execute git log with the provided arguments.
 
@@ -42,7 +41,6 @@ async def git_log(
         arguments: Optional arguments to pass to git log as a string
         path: The directory to execute the command in (must be in a git repository)
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A dictionary with git log output

--- a/codemcp/tools/git_show.py
+++ b/codemcp/tools/git_show.py
@@ -36,7 +36,6 @@ async def git_show(
     arguments: str | None = None,
     path: str | None = None,
     chat_id: str | None = None,
-    signal=None,
 ) -> dict[str, Any]:
     """Execute git show with the provided arguments.
 
@@ -44,7 +43,6 @@ async def git_show(
         arguments: Optional arguments to pass to git show as a string
         path: The directory to execute the command in (must be in a git repository)
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A dictionary with git show output

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -22,7 +22,6 @@ async def glob(
     pattern: str,
     path: str,
     options: Optional[Dict[str, Any]] = None,
-    signal=None,
 ) -> Dict[str, Any]:
     """Find files matching a glob pattern.
 
@@ -30,7 +29,6 @@ async def glob(
         pattern: The glob pattern to match files against
         path: The directory to search in
         options: Optional parameters for pagination (limit, offset)
-        signal: Optional abort signal to terminate the operation
 
     Returns:
         A dictionary with matched files and metadata
@@ -148,7 +146,6 @@ async def glob_files(
     limit: int = MAX_RESULTS,
     offset: int = 0,
     chat_id: str | None = None,
-    signal=None,
 ) -> Dict[str, Any]:
     """Search for files matching a glob pattern.
 
@@ -158,7 +155,6 @@ async def glob_files(
         limit: Maximum number of results to return
         offset: Number of results to skip (for pagination)
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the operation
 
     Returns:
         A dictionary with matched files
@@ -174,7 +170,7 @@ async def glob_files(
     }
 
     # Execute glob
-    result = await glob(pattern, path, options, signal)
+    result = await glob(pattern, path, options)
 
     # Get matching files
     files = result.get("files", [])

--- a/codemcp/tools/grep.py
+++ b/codemcp/tools/grep.py
@@ -36,7 +36,6 @@ async def git_grep(
     pattern: str,
     path: str | None = None,
     include: str | None = None,
-    signal=None,
 ) -> list[str]:
     """Execute git grep to search for pattern in files.
 
@@ -44,7 +43,6 @@ async def git_grep(
         pattern: The regular expression pattern to search for
         path: The directory or file to search in (must be in a git repository)
         include: Optional file pattern to filter the search
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A list of file paths with matches
@@ -119,7 +117,7 @@ async def git_grep(
             raise subprocess.SubprocessError(f"git grep failed: {result.stderr}")
 
         # Process results - split by newline and filter empty lines
-        matches = [line.strip() for line in result.stdout.split("\n") if line.strip()]
+        matches = [line.strip() for line in result.stdout.split() if line.strip()]
 
         # Convert to absolute paths
         matches = [os.path.join(absolute_path, match) for match in matches]
@@ -160,7 +158,6 @@ async def grep_files(
     path: str | None = None,
     include: str | None = None,
     chat_id: str | None = None,
-    signal=None,
 ) -> dict[str, Any]:
     """Search for a pattern in files within a directory or in a specific file.
 
@@ -169,7 +166,6 @@ async def grep_files(
         path: The directory or file to search in (must be in a git repository)
         include: Optional file pattern to filter the search
         chat_id: The unique ID of the current chat session
-        signal: Optional abort signal to terminate the subprocess
 
     Returns:
         A dictionary with matched files
@@ -177,7 +173,7 @@ async def grep_files(
     """
 
     # Execute git grep asynchronously
-    matches = await git_grep(pattern, path, include, signal)
+    matches = await git_grep(pattern, path, include)
 
     # Sort matches
     # Use asyncio for getting file stats

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import re
+from typing import Dict, Optional
 
 import tomli
 
@@ -37,7 +38,7 @@ def _slugify(text: str) -> str:
     return text[:50]
 
 
-def _generate_command_docs(command_docs: dict) -> str:
+def _generate_command_docs(command_docs: Dict[str, str]) -> str:
     """Generate documentation for commands from the command_docs dictionary.
 
     Args:
@@ -56,7 +57,7 @@ def _generate_command_docs(command_docs: dict) -> str:
     return "\n\nCommand documentation:" + "".join(docs)
 
 
-async def _generate_chat_id(directory: str, description: str = None) -> str:
+async def _generate_chat_id(directory: str, description: Optional[str] = None) -> str:
     """Generate a unique chat ID based on a counter stored in the git repository.
 
     Args:
@@ -198,7 +199,7 @@ async def init_project(
 
         # Create a commit reference instead of creating a regular commit
         # This will not advance HEAD but store the commit in refs/codemcp/<chat_id>
-        message, commit_hash = await create_commit_reference(
+        _, _ = await create_commit_reference(
             full_dir_path,
             chat_id=chat_id,
             commit_msg=commit_msg,

--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -16,7 +16,7 @@ __all__ = [
 async def rm_file(
     path: str,
     description: str,
-    chat_id: str = None,
+    chat_id: str = "",
 ) -> str:
     """Remove a file using git rm.
 

--- a/codemcp/tools/run_command.py
+++ b/codemcp/tools/run_command.py
@@ -14,7 +14,7 @@ async def run_command(
     project_dir: str,
     command: str,
     arguments: Optional[str] = None,
-    chat_id: str = None,
+    chat_id: str = "",
 ) -> str:
     """Run a command that is configured in codemcp.toml.
 
@@ -38,6 +38,9 @@ async def run_command(
         parsed_args = shlex.split(arguments)
         command_list.extend(parsed_args)
 
+    # Don't pass None to run_code_command
+    actual_command = command_list if command_list is not None else []
+
     return await run_code_command(
-        project_dir, command, command_list, f"Auto-commit {command} changes", chat_id
+        project_dir, command, actual_command, f"Auto-commit {command} changes", chat_id
     )

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 async def write_file_content(
-    file_path: str, content: str, description: str = "", chat_id: str = None
+    file_path: str, content: str, description: str = "", chat_id: str = ""
 ) -> str:
     """Write content to a file.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #225
* #224
* #223
* #221
* #220
* #219
* #218
* __->__ #217
* #216

Typecheck and fix all errors in codemcp/tools/

```git-revs
79b88dc  (Base revision)
950c78a  Add AsyncAbortSignal protocol for type checking
2bf74a9  Import AsyncAbortSignal in chmod.py
fc9a1a3  Add AsyncAbortSignal type annotation to chmod function
21d64ee  Ensure chat_id is not None when calling commit_changes
b472620  Import AsyncAbortSignal in git_blame.py
9350d33  Add AsyncAbortSignal type annotation to git_blame function
e712304  Remove codemcp/signal_types.py: Remove unnecessary signal_types.py
dff8f2a  Remove unnecessary AsyncAbortSignal import in chmod.py
86c5519  Change signal parameter type to Any in chmod.py
21c0a41  Remove unnecessary AsyncAbortSignal import in git_blame.py
af0ea51  Change signal parameter type to Any in git_blame.py
a7aa14f  Add proper type annotation for signal parameter in git_diff.py
21ddade  Add proper type annotation for signal parameter in git_log.py
beb86ab  Remove unused signal parameter from git_show.py
5862d82  Remove unused signal parameter from git_blame.py
9e37110  Remove unused signal parameter from git_diff.py
6d3d32a  Remove unused signal parameter from git_log.py
38d525f  Remove unused signal parameter from chmod.py
f11bd7a  Remove signal parameter from chmod.py docstring
758b714  Remove signal parameter from git_blame.py docstring
9580448  Remove signal parameter from git_diff.py docstring
5185135  Remove signal parameter from git_log.py docstring
d07756a  Remove signal parameter from git_show.py docstring
56af8e6  Remove unused signal parameter from glob.py
d0c0a3e  Remove signal parameter from glob.py docstring
acc9507  Remove unused signal parameter from glob_files function
be65e0e  Remove signal parameter from glob_files docstring
a08963b  Remove unused signal parameter from git_grep function
f98cc86  Remove signal parameter from git_grep docstring
793a395  Remove unused signal parameter from grep_files function
d80863a  Remove signal parameter from grep_files docstring
1286918  Update git_grep call to remove signal parameter
17d29cf  Fix split() in grep.py to correctly split string
7be44fd  Initialize best_match_i to fix possible unbound variable error
38320cd  Initialize best_match with empty list to avoid None checks
def9944  Add check for empty search_lines or content_lines
a08d108  Add proper type annotation for dict in apply_edit return type
5232434  Add Any to imports in edit_file.py
a3a5f83  Fix zip function call in try_dotdotdots to handle type checking correctly
35fd1cf  Fix default value for chat_id to use empty string instead of None
28acdaa  Fix default value for chat_id to use empty string instead of None
c351e11  Fix default value for chat_id to use empty string instead of None
8739877  Add required type imports in init_project.py
3006ef7  Add proper type annotation for command_docs parameter
3b1f3fa  Fix description parameter type in _generate_chat_id function
f6ef39c  Fix unused variables in init_project.py by using _ to discard returned values
1096afc  Remove unused Optional import
56b2265  Remove unused Any import
614362e  Fix unused variable 'patch' in edit_file.py by using _ to discard returned value
8f27a3d  Fix glob function call to remove signal parameter
09a56ce  Handle None case for command_list in run_command.py
HEAD     Update run_code_command call to use actual_command
```

codemcp-id: 227-fix-type-checking-errors-in-tools-directory