### PR TITLE
fix: type checking and error fixes

### DIFF
--- a/codemcp/hot_reload_entry.py
+++ b/codemcp/hot_reload_entry.py
@@ -162,7 +162,9 @@ class HotReloadManager:
                             break
 
                         if command == "call":
-                            result = await session.call_tool("codemcp", arguments=args)
+                            result = await session.call_tool(
+                                name="codemcp", arguments=args
+                            )
                             # This is the only error case FastMCP can
                             # faithfully re-propagate, see
                             # https://github.com/modelcontextprotocol/python-sdk/issues/348

--- a/codemcp/multi_entry.py
+++ b/codemcp/multi_entry.py
@@ -11,38 +11,57 @@ from codemcp.tools.write_file import write_file_content
 mcp = FastMCP("codemcp_multi")
 
 
+# Helper function to get a chat_id from a Context
+def get_chat_id_from_context(ctx: Context) -> str:
+    # Generate a chat_id from the context
+    ctx_id = getattr(ctx, "id", None)
+    return f"multi-{ctx_id}" if ctx_id else "multi-default"
+
+
 @mcp.tool()
 async def read_file(
-    ctx: Context, file_path: str, offset: int = None, limit: int = None
+    ctx: Context, file_path: str, offset: int | None = None, limit: int | None = None
 ) -> str:
-    return await read_file_content(file_path, offset, limit)
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await read_file_content(file_path, offset, limit, chat_id)
 
 
 @mcp.tool()
 async def write_file(
     ctx: Context, file_path: str, content: str, description: str
 ) -> str:
-    return await write_file_content(file_path, content, description)
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await write_file_content(file_path, content, description, chat_id)
 
 
 @mcp.tool()
 async def edit_file(
     ctx: Context, file_path: str, old_string: str, new_string: str, description: str
 ) -> str:
-    return await edit_file_content(file_path, old_string, new_string, None, description)
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await edit_file_content(
+        file_path, old_string, new_string, None, description, chat_id
+    )
 
 
 @mcp.tool()
 async def ls(ctx: Context, file_path: str) -> str:
-    return await ls_directory(file_path)
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await ls_directory(file_path, chat_id)
 
 
 @mcp.tool()
 async def grep(
-    ctx: Context, pattern: str, path: str = None, include: str = None
+    ctx: Context, pattern: str, path: str | None = None, include: str | None = None
 ) -> str:
-    result = grep_files(pattern, path, include)
-    return await result.get(
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    result = await grep_files(pattern, path, include, chat_id)
+    return result.get(
         "resultForAssistant", f"Found {result.get('numFiles', 0)} file(s)"
     )
 
@@ -55,6 +74,8 @@ async def init_project_tool(
     subject_line: str,
     reuse_head_chat_id: bool = False,
 ) -> str:
+    # The init_project function actually doesn't accept a chat_id parameter
+    # It generates its own chat_id, so we don't pass it as an argument
     return await init_project(file_path, user_prompt, subject_line, reuse_head_chat_id)
 
 

--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -413,20 +413,20 @@ def find_similar_lines(
         String containing the most similar lines, or empty string if none found
 
     """
-    search_lines = search_lines.splitlines()
-    content_lines = content_lines.splitlines()
+    search_lines_list = search_lines.splitlines()
+    content_lines_list = content_lines.splitlines()
 
     # Handle empty input cases
-    if not search_lines or not content_lines:
+    if not search_lines_list or not content_lines_list:
         return ""
 
     best_ratio = 0
-    best_match = []  # Initialize with empty list to avoid None checks
+    best_match: list[str] = []  # Initialize with empty list to avoid None checks
     best_match_i = 0  # Initialize to avoid unbound variable errors
 
-    for i in range(len(content_lines) - len(search_lines) + 1):
-        chunk = content_lines[i : i + len(search_lines)]
-        ratio = SequenceMatcher(None, search_lines, chunk).ratio()
+    for i in range(len(content_lines_list) - len(search_lines_list) + 1):
+        chunk = content_lines_list[i : i + len(search_lines_list)]
+        ratio = SequenceMatcher(None, search_lines_list, chunk).ratio()
         if ratio > best_ratio:
             best_ratio = ratio
             best_match = chunk
@@ -435,14 +435,19 @@ def find_similar_lines(
     if best_ratio < threshold:
         return ""
 
-    if best_match[0] == search_lines[0] and best_match[-1] == search_lines[-1]:
+    if (
+        best_match[0] == search_lines_list[0]
+        and best_match[-1] == search_lines_list[-1]
+    ):
         return "\n".join(best_match)
 
     N = 5
-    best_match_end = min(len(content_lines), best_match_i + len(search_lines) + N)
+    best_match_end = min(
+        len(content_lines_list), best_match_i + len(search_lines_list) + N
+    )
     best_match_i = max(0, best_match_i - N)
 
-    best = content_lines[best_match_i:best_match_end]
+    best = content_lines_list[best_match_i:best_match_end]
     return "\n".join(best)
 
 
@@ -584,7 +589,7 @@ async def edit_file_content(
     new_string: str,
     read_file_timestamps: dict[str, float] | None = None,
     description: str = "",
-    chat_id: str = None,
+    chat_id: str = "",
 ) -> str:
     """Edit a file by replacing old_string with new_string.
 

--- a/e2e/test_chmod.py
+++ b/e2e/test_chmod.py
@@ -135,7 +135,12 @@ class ChmodTest(MCPEndToEndTestCase):
                     "chat_id": chat_id,
                 },
             )
-            self.assertIn("unsupported chmod mode", error_text.lower())
+            # Check for either error message (from main.py or chmod.py)
+            self.assertTrue(
+                "unsupported chmod mode" in error_text.lower() or
+                "mode must be either 'a+x' or 'a-x'" in error_text.lower(),
+                f"Expected an error about invalid mode, but got: {error_text}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #225
* #224
* #223
* #221
* #220
* #219
* __->__ #218
* #217
* #216

Typecheck and fix errors

```git-revs
501e45e  (Base revision)
f61a404  Fix arguments type in codemcp function signature
99e84c8  Add type annotation for normalize_newlines function
1babe5e  Ensure arguments passed to run_command is of type str or None
e24a52b  Ensure chat_id is not None when calling write_file_content
b49ec73  Ensure chat_id is not None when calling edit_file_content
4eb193e  Ensure chat_id is not None when calling rm_file
1327d56  Validate chmod mode parameter and ensure chat_id is not None
10dd9ad  Add parameter type annotation to configure_logging function
06944fb  Add parameter and return type annotations to ModuleFilter.filter method
efc28c8  Add parameter and return type annotations to cli function
7016544  Add parameter and return type annotations to init function
a5a85a0  Add return type annotation to run function
6db300e  Fix call_tool parameter naming to clarify types
d935379  Fix optional integer parameters in read_file function
ed70a05  Add chat_id parameter to read_file_content call
c874bf0  Add chat_id parameter to write_file_content call
82046df  Add chat_id parameter to edit_file_content call
b30b7c4  Add chat_id parameter to ls_directory call
a1a94d5  Fix grep_files call with proper types and add chat_id parameter
d29bac7  Add chat_id parameter to init_project call
32c4d58  Fix line list type issues in find_similar_lines function
cfdb062  Fix type errors with normalized parameter values
a385183  Add explicit check for chat_id in RunCommand subtool
2f7a14b  Use type casting for mode parameter in chmod call
bc96ae1  Add default return value to ensure function always returns a string
a05e6e1  Add helper function to safely get chat_id from Context and add necessary imports
bec3320  Update read_file function to use the helper function
e3110d2  Update write_file function to use the helper function
9af4d12  Update edit_file function to use the helper function
5b78250  Update ls function to use the helper function
bc12fab  Update grep function to use the helper function
1deb4ca  Update init_project_tool function to use the helper function
a9483d7  Fix default value for chat_id parameter in edit_file_content
200c345  Fix init_project function call by removing the chat_id parameter
0653554  Remove unused Optional import
fd4e907  Remove unused import in multi_entry.py
71f0bc4  Remove unused chat_id variable
6c469b6  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 228-fix-type-checking-and-error-fixes