### PR TITLE
feat: add Python argument to init command

### DIFF
--- a/codemcp/templates/blank/codemcp.toml
+++ b/codemcp/templates/blank/codemcp.toml
@@ -1,0 +1,1 @@
+# codemcp configuration file

--- a/codemcp/templates/python/README.md
+++ b/codemcp/templates/python/README.md
@@ -1,0 +1,3 @@
+# __PROJECT_NAME__
+
+Project description

--- a/codemcp/templates/python/__PACKAGE_NAME__/__init__.py
+++ b/codemcp/templates/python/__PACKAGE_NAME__/__init__.py
@@ -1,0 +1,3 @@
+"""__PROJECT_NAME__ package."""
+
+__version__ = "0.1.0"

--- a/codemcp/templates/python/__init__.py
+++ b/codemcp/templates/python/__init__.py
@@ -1,0 +1,3 @@
+"""__PROJECT_NAME__ package."""
+
+__version__ = "0.1.0"

--- a/codemcp/templates/python/codemcp.toml
+++ b/codemcp/templates/python/codemcp.toml
@@ -1,0 +1,1 @@
+# codemcp configuration file for __PROJECT_NAME__

--- a/codemcp/templates/python/package/__init__.py
+++ b/codemcp/templates/python/package/__init__.py
@@ -1,0 +1,3 @@
+"""__PROJECT_NAME__ package."""
+
+__version__ = "0.1.0"

--- a/codemcp/templates/python/pyproject.toml
+++ b/codemcp/templates/python/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "__PROJECT_NAME__"
+version = "0.1.0"
+description = "Project description"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "mypy>=1.0.0",
+    "black>=23.0.0",
+    "isort>=5.0.0",
+]

--- a/e2e/test_init_command.py
+++ b/e2e/test_init_command.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -73,8 +74,12 @@ def test_init_command_existing_repo():
 
 def test_init_command_with_python():
     """Test the init command with Python option creates Python project structure."""
-    # Create a temporary directory for testing
-    with tempfile.TemporaryDirectory() as temp_dir:
+    # Create a temporary directory for testing with a specific name
+    with tempfile.TemporaryDirectory(prefix="test-project-") as temp_dir:
+        temp_path = Path(temp_dir)
+        project_name = temp_path.name  # Get the directory name
+        package_name = re.sub(r"[^a-z0-9_]", "_", project_name.lower())
+
         # Run the init_codemcp_project function with Python option
         result = init_codemcp_project(temp_dir, python=True)
 
@@ -83,26 +88,36 @@ def test_init_command_with_python():
         assert "with Python project structure" in result
 
         # Check that standard files were created
-        config_file = Path(temp_dir) / "codemcp.toml"
+        config_file = temp_path / "codemcp.toml"
         assert config_file.exists()
 
         # Check that git repository was initialized
-        git_dir = Path(temp_dir) / ".git"
+        git_dir = temp_path / ".git"
         assert git_dir.is_dir()
 
         # Check that Python-specific files were created
-        pyproject_file = Path(temp_dir) / "pyproject.toml"
+        pyproject_file = temp_path / "pyproject.toml"
         assert pyproject_file.exists()
 
-        readme_file = Path(temp_dir) / "README.md"
+        # Check if the project name was correctly applied in pyproject.toml
+        with open(pyproject_file, "r") as f:
+            content = f.read()
+            assert project_name in content
+
+        readme_file = temp_path / "README.md"
         assert readme_file.exists()
 
-        # Check package structure
-        package_dir = Path(temp_dir) / "project_name"
+        # Check package structure with correct name derived from directory
+        package_dir = temp_path / package_name
         assert package_dir.is_dir()
 
         init_file = package_dir / "__init__.py"
         assert init_file.exists()
+
+        # Check if __init__.py contains the correct project name
+        with open(init_file, "r") as f:
+            content = f.read()
+            assert project_name in content
 
         # Check that the commit message includes Python template reference
         result = subprocess.run(

--- a/e2e/test_init_command.py
+++ b/e2e/test_init_command.py
@@ -69,3 +69,47 @@ def test_init_command_existing_repo():
         # Check that codemcp.toml was created
         config_file = Path(temp_dir) / "codemcp.toml"
         assert config_file.exists()
+
+
+def test_init_command_with_python():
+    """Test the init command with Python option creates Python project structure."""
+    # Create a temporary directory for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Run the init_codemcp_project function with Python option
+        result = init_codemcp_project(temp_dir, python=True)
+
+        # Check that the function reports success with Python message
+        assert "Successfully initialized" in result
+        assert "with Python project structure" in result
+
+        # Check that standard files were created
+        config_file = Path(temp_dir) / "codemcp.toml"
+        assert config_file.exists()
+
+        # Check that git repository was initialized
+        git_dir = Path(temp_dir) / ".git"
+        assert git_dir.is_dir()
+
+        # Check that Python-specific files were created
+        pyproject_file = Path(temp_dir) / "pyproject.toml"
+        assert pyproject_file.exists()
+
+        readme_file = Path(temp_dir) / "README.md"
+        assert readme_file.exists()
+
+        # Check package structure
+        package_dir = Path(temp_dir) / "project_name"
+        assert package_dir.is_dir()
+
+        init_file = package_dir / "__init__.py"
+        assert init_file.exists()
+
+        # Check that the commit message includes Python template reference
+        result = subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=temp_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "with Python template" in result.stdout


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #233
* #229
* #232
* #228
* __->__ #226
* #230

main.py add a --python argument to init

```git-revs
8c4b3f2  (Base revision)
2fefadb  Update init_codemcp_project function to add Python project setup functionality
b1920d9  Update the init CLI command to accept the --python flag
1e3fbc3  Add test for the init command with Python option
HEAD     Auto-commit format changes
```

codemcp-id: 237-feat-add-python-argument-to-init-command