### PR TITLE
test: Update tests to accommodate trailing newline changes

### DIFF
--- a/e2e/test_directory_creation.py
+++ b/e2e/test_directory_creation.py
@@ -55,7 +55,7 @@ class DirectoryCreationTest(MCPEndToEndTestCase):
             self.assertTrue(os.path.exists(test_file_path), "File was not created")
             with open(test_file_path) as f:
                 file_content = f.read()
-            self.assertEqual(file_content, content)
+            self.assertEqual(file_content, content + "\n")
 
     async def test_edit_file_nested_directories(self):
         """Test EditFile can create nested directories when old_string is empty."""
@@ -100,7 +100,7 @@ class DirectoryCreationTest(MCPEndToEndTestCase):
             self.assertTrue(os.path.exists(test_file_path), "File was not created")
             with open(test_file_path) as f:
                 file_content = f.read()
-            self.assertEqual(file_content, content)
+            self.assertEqual(file_content, content + "\n")
 
 
 if __name__ == "__main__":

--- a/e2e/test_edit_file.py
+++ b/e2e/test_edit_file.py
@@ -206,7 +206,7 @@ nothing to commit, working tree clean""",
             # Read the content to verify it was written correctly
             with open(new_file_path) as f:
                 content = f.read()
-            self.assertEqual(content, "This file in untracked dir")
+            self.assertEqual(content, "This file in untracked dir\n")
 
             # For this test, we'll manually add and commit the file
             # This is a change in the test expectation since we don't need automatic git tracking
@@ -298,7 +298,7 @@ nothing to commit, working tree clean""",
                 # SECURITY CHECK: Read file content to confirm it was written correctly
                 with open(tracked_file_path) as f:
                     content = f.read()
-                self.assertEqual(content, "Attempt to write to git-removed file")
+                self.assertEqual(content, "Attempt to write to git-removed file\n")
 
                 # Check if the recreated file is tracked in git
                 status_after = await self.git_run(

--- a/e2e/test_hot_reload_entry.py
+++ b/e2e/test_hot_reload_entry.py
@@ -86,7 +86,7 @@ class TestHotReloadEntry(MCPEndToEndTestCase):
         # Read the file to verify contents were written correctly
         with open(test_file_path, "r") as f:
             file_content = f.read()
-        self.assertEqual(file_content, new_content)
+        self.assertEqual(file_content, new_content + "\n")
 
     async def test_error_handling(self):
         """Test that errors from the main module are properly propagated through hot_reload_entry."""

--- a/e2e/test_json_content_serialization.py
+++ b/e2e/test_json_content_serialization.py
@@ -27,7 +27,7 @@ class JsonContentSerializationTest(MCPEndToEndTestCase):
         }
 
         # Expected serialized string for verification
-        expected_content = json.dumps(content_dict)
+        expected_content = json.dumps(content_dict) + "\n"
 
         async with self.create_client_session() as session:
             # First initialize project to get chat_id
@@ -70,7 +70,7 @@ class JsonContentSerializationTest(MCPEndToEndTestCase):
 
             # Test with a list
             content_list = [1, "two", 3.0, False, None]
-            expected_list_content = json.dumps(content_list)
+            expected_list_content = json.dumps(content_list) + "\n"
             list_file_path = os.path.join(self.temp_dir.name, "list_serialized.txt")
 
             # Call WriteFile with a list as content

--- a/e2e/test_write_file.py
+++ b/e2e/test_write_file.py
@@ -62,7 +62,7 @@ class WriteFileTest(MCPEndToEndTestCase):
             # Verify the file was created with the correct content
             with open(test_file_path) as f:
                 file_content = f.read()
-            self.assertEqual(file_content, content)
+            self.assertEqual(file_content, content + "\n")
 
             # Verify git state (working tree should be clean after automatic commit)
             status = await self.git_run(["status"], capture_output=True, text=True)
@@ -121,7 +121,7 @@ codemcp-id: test-chat-id""",
             # Verify the file was updated with the correct content
             with open(test_file_path) as f:
                 file_content = f.read()
-            self.assertEqual(file_content, updated_content)
+            self.assertEqual(file_content, updated_content + "\n")
 
             # Verify git state after second write
             status = await self.git_run(["status"], capture_output=True, text=True)
@@ -152,7 +152,7 @@ Test initialization for write_file test
 
 ```git-revs
 c9bcf9c  (Base revision)
-a0816d8  Create new file
+49bf8ff  Create new file
 HEAD     Update file with third line
 ```
 
@@ -211,7 +211,7 @@ codemcp-id: test-chat-id""",
             # Check content
             with open(new_file_path) as f:
                 content = f.read()
-            self.assertEqual(content, "This is a brand new file")
+            self.assertEqual(content, "This is a brand new file\n")
 
             # Verify the file was added to git
             ls_files_output = await self.git_run(
@@ -434,7 +434,7 @@ And make sure it runs correctly."""
             # Verify the file was created with the correct content
             with open(test_file_path) as f:
                 file_content = f.read()
-            self.assertEqual(file_content, content)
+            self.assertEqual(file_content, content + "\n")
 
             # Get the commit message of the HEAD commit
             commit_message = await self.git_run(
@@ -493,7 +493,7 @@ codemcp-id: test-chat-id""",
             # Verify the file was updated with the correct content
             with open(test_file_path) as f:
                 file_content = f.read()
-            self.assertEqual(file_content, updated_content)
+            self.assertEqual(file_content, updated_content + "\n")
 
             # Get the commit message after second write
             commit_message = await self.git_run(
@@ -524,7 +524,7 @@ And make sure it runs correctly.
 
 ```git-revs
 6350984  (Base revision)
-9071fd5  Write file from prompt with code block
+52d0290  Write file from prompt with code block
 HEAD     Update file with second write
 ```
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

We recently changed how we deal with trailing newlines. Tests are failing, the tests need to be updated (implementation is correct).

```git-revs
fea0625  (Base revision)
4eef696  Update test_write_file_nested_directories to expect trailing newline in written file
f818ab6  Update test_edit_file_nested_directories to expect trailing newline in created file
960a8b3  Update test_create_file_with_edit_file_in_untracked_dir to expect trailing newline
30d064a  Update test_edit_after_git_rm to expect trailing newline in file content
9d20cd0  Update test_hot_reload_with_parameters to expect trailing newline in file content
360c92b  Update test_json_serialization to expect trailing newline in JSON content
fa473e5  Update test with list to expect trailing newline in JSON content
e797fcf  Update test_create_new_file_with_write_file to expect trailing newline in file content
84707ad  Update first test_write_file test to expect trailing newline in file content
7196482  Update second write test to expect trailing newline in file content
6d2bdba  Update test_user_prompt_with_markdown_code_block to expect trailing newline
15ff292  Snapshot before codemcp change
03647c9  Update test_user_prompt_with_markdown_code_block second assertion to expect trailing newline
HEAD     Snapshot before codemcp change
```

codemcp-id: 241-test-update-tests-to-accommodate-trailing-newline-