### PR TITLE
fix: include template files in package installation

### DIFF
--- a/codemcp/agno.py
+++ b/codemcp/agno.py
@@ -62,9 +62,7 @@ async def serve_playground_app_async(
 
 
 async def main():
-    async with MCPTools(
-        f"{sys.executable()} -m codemcp.hot_reload_entry"
-    ) as codemcp:
+    async with MCPTools(f"{sys.executable()} -m codemcp.hot_reload_entry") as codemcp:
         # TODO: cli-ify the model
         agent = Agent(
             model=Claude(id="claude-3-7-sonnet-20250219"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,19 @@ codemcp-multi = "codemcp.multi_entry:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["codemcp"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/codemcp",
+    "/README.md",
+    "pyproject.toml",
+]
+
+[tool.hatch.build.force-include]
+"codemcp/templates" = "codemcp/templates"
+
 [tool.uv]
 
 [tool.ruff]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

codemcp/templates/ contains data files that aren't Python files per se, but they need to be installed properly so that they're available to be copied when we run codemcp init. Fix pyproject.toml so that we correctly include the data files. I think I want to recursively glob everything that isn't excluded by .gitignore, but if it's best practice to directly only package things that are Git versioned that would work too (not sure how you gonna do source tarballs that way though.)

```git-revs
3f886df  (Base revision)
d77a938  Add Hatchling configuration to include template files in package build
HEAD     Auto-commit format changes
```

codemcp-id: 253-fix-include-template-files-in-package-installation