### PR TITLE
fix: respect .gitignore in template directory glob

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -397,6 +397,78 @@ async def codemcp(
     return "Unknown subtool or operation"
 
 
+def get_files_respecting_gitignore(dir_path: Path, pattern: str = "**/*") -> List[Path]:
+    """Get files in a directory respecting .gitignore rules in all subdirectories.
+
+    Args:
+        dir_path: The directory path to search in
+        pattern: The glob pattern to match files against (default: "**/*")
+
+    Returns:
+        A list of Path objects for files that match the pattern and respect .gitignore
+    """
+    # First collect all files and directories
+    all_paths = list(dir_path.glob(pattern))
+    all_files = [p for p in all_paths if p.is_file()]
+    all_dirs = [dir_path] + [p for p in all_paths if p.is_dir()]
+
+    # Find all .gitignore files in the directory and subdirectories
+    gitignore_specs = {}
+
+    # Process .gitignore files from root to leaf directories
+    for directory in sorted(all_dirs, key=lambda d: str(d)):
+        gitignore_path = directory / ".gitignore"
+        if gitignore_path.exists() and gitignore_path.is_file():
+            try:
+                with open(gitignore_path, "r") as ignore_file:
+                    ignore_lines = ignore_file.readlines()
+                    gitignore_specs[directory] = pathspec.GitIgnoreSpec.from_lines(
+                        ignore_lines
+                    )
+            except Exception as e:
+                # Log error but continue processing
+                logging.warning(f"Error reading .gitignore in {directory}: {e}")
+
+    # If no .gitignore files found, return all files
+    if not gitignore_specs:
+        return [f for f in all_files if f.is_file()]
+
+    # Helper function to check if a path is ignored by any relevant .gitignore
+    def is_ignored(path: Path) -> bool:
+        """
+        Check if a path should be ignored according to .gitignore rules.
+
+        This checks the path against all .gitignore files in its parent directories.
+        """
+        # For files, we need to check if any parent directory is ignored first
+        if path.is_file():
+            # Check if any parent directory is ignored
+            current_dir = path.parent
+            while current_dir.is_relative_to(dir_path):
+                if is_ignored(current_dir):
+                    return True
+                current_dir = current_dir.parent
+
+        # Now check the path against all relevant .gitignore specs
+        for spec_dir, spec in gitignore_specs.items():
+            # Only apply specs from parent directories of the path
+            if path.is_relative_to(spec_dir):
+                # Get the path relative to the directory containing the .gitignore
+                rel_path = str(path.relative_to(spec_dir))
+                # Empty string means the directory itself
+                if not rel_path:
+                    rel_path = "."
+                # Check if path matches any pattern in the .gitignore
+                if spec.match_file(rel_path):
+                    return True
+
+        return False
+
+    # Filter out ignored files
+    result = [f for f in all_files if not is_ignored(f)]
+    return result
+
+
 def configure_logging(log_file: str = "codemcp.log") -> None:
     """Configure logging to write to both a file and the console.
 
@@ -524,80 +596,6 @@ def init_codemcp_project(path: str, python: bool = False) -> str:
 
     # Track which files we need to add to git
     files_to_add = []
-
-    # Function to get files respecting .gitignore
-    def get_files_respecting_gitignore(
-        dir_path: Path, pattern: str = "**/*"
-    ) -> List[Path]:
-        """Get files in a directory respecting .gitignore rules in all subdirectories.
-
-        Args:
-            dir_path: The directory path to search in
-            pattern: The glob pattern to match files against (default: "**/*")
-
-        Returns:
-            A list of Path objects for files that match the pattern and respect .gitignore
-        """
-        # First collect all files and directories
-        all_paths = list(dir_path.glob(pattern))
-        all_files = [p for p in all_paths if p.is_file()]
-        all_dirs = [dir_path] + [p for p in all_paths if p.is_dir()]
-
-        # Find all .gitignore files in the directory and subdirectories
-        gitignore_specs = {}
-
-        # Process .gitignore files from root to leaf directories
-        for directory in sorted(all_dirs, key=lambda d: str(d)):
-            gitignore_path = directory / ".gitignore"
-            if gitignore_path.exists() and gitignore_path.is_file():
-                try:
-                    with open(gitignore_path, "r") as ignore_file:
-                        ignore_lines = ignore_file.readlines()
-                        gitignore_specs[directory] = pathspec.GitIgnoreSpec.from_lines(
-                            ignore_lines
-                        )
-                except Exception as e:
-                    # Log error but continue processing
-                    logging.warning(f"Error reading .gitignore in {directory}: {e}")
-
-        # If no .gitignore files found, return all files
-        if not gitignore_specs:
-            return [f for f in all_files if f.is_file()]
-
-        # Helper function to check if a path is ignored by any relevant .gitignore
-        def is_ignored(path: Path) -> bool:
-            """
-            Check if a path should be ignored according to .gitignore rules.
-
-            This checks the path against all .gitignore files in its parent directories.
-            """
-            # For files, we need to check if any parent directory is ignored first
-            if path.is_file():
-                # Check if any parent directory is ignored
-                current_dir = path.parent
-                while current_dir.is_relative_to(dir_path):
-                    if is_ignored(current_dir):
-                        return True
-                    current_dir = current_dir.parent
-
-            # Now check the path against all relevant .gitignore specs
-            for spec_dir, spec in gitignore_specs.items():
-                # Only apply specs from parent directories of the path
-                if path.is_relative_to(spec_dir):
-                    # Get the path relative to the directory containing the .gitignore
-                    rel_path = str(path.relative_to(spec_dir))
-                    # Empty string means the directory itself
-                    if not rel_path:
-                        rel_path = "."
-                    # Check if path matches any pattern in the .gitignore
-                    if spec.match_file(rel_path):
-                        return True
-
-            return False
-
-        # Filter out ignored files
-        result = [f for f in all_files if not is_ignored(f)]
-        return result
 
     # Function to replace placeholders in a string
     def replace_placeholders(text):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #244
* #243
* #241
* #240
* #239

codemcp/main.py:
# Recursively process template directory for template_file in templates_dir.glob("**/*"):
This glob is incorrect; we need to use the same glob pattern that Hatch would use to collect files, importantly, we must respect .gitignore to exclude files here.

```git-revs
55bc199  (Base revision)
14f8494  Add pathspec import for handling gitignore patterns
17cdec0  Add helper function to get files respecting .gitignore
cde369f  Update template processing to respect .gitignore
c35fa81  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 254-fix-respect-gitignore-in-template-directory-glob