### PR TITLE
feat: use git commit hash instead of static chat id

### DIFF
--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -15,6 +15,7 @@ __all__ = [
     "is_git_repository",
     "get_ref_commit_chat_id",
     "find_git_root",
+    "get_current_commit_hash",
 ]
 
 log = logging.getLogger(__name__)
@@ -246,3 +247,46 @@ def find_git_root(start_path: str) -> str | None:
         path = parent
 
     return None
+
+
+async def get_current_commit_hash(directory: str, short: bool = True) -> str | None:
+    """Get the current commit hash for the repository.
+
+    This function is similar to get_head_commit_hash but designed to be used
+    after operations to report the latest commit hash.
+
+    Args:
+        directory: The directory to check
+        short: Whether to get short hash (default) or full hash
+
+    Returns:
+        The current commit hash if available, None otherwise
+
+    Note:
+        This function safely returns None if there are any issues getting the hash,
+        rather than raising exceptions.
+    """
+    try:
+        if not await is_git_repository(directory):
+            return None
+
+        # Get the commit hash (short or full)
+        cmd = ["git", "rev-parse"]
+        if short:
+            cmd.append("--short")
+        cmd.append("HEAD")
+
+        result = await run_command(
+            cmd,
+            cwd=directory,
+            check=False,  # Don't raise exception if command fails
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            return str(result.stdout.strip())
+        return None
+    except Exception as e:
+        logging.warning(f"Exception when getting current commit hash: {e!s}", exc_info=True)
+        return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Instead of passing a single static chat id across all conversations, we're going to pass the current Git commit hash. Whenever a command returns, we will query and report what the new current commit hash is in the output. Update the system prompt to ensure that we maintain a current commit hash state and pass it / update it to all tool calls. Do NOT manually update every subtool, instead, there should be unified handling in the codemcp tool main body.

```git-revs
1df0498  (Base revision)
df80e3b  Add get_current_commit_hash to __all__ exports
HEAD     Add get_current_commit_hash function
```

codemcp-id: 256-feat-use-git-commit-hash-instead-of-static-chat-id