### PR TITLE
feat: replace playground with stdin loop in agno.py

### DIFF
--- a/codemcp/agno.py
+++ b/codemcp/agno.py
@@ -7,9 +7,7 @@ from agno.agent import Agent
 from agno.api.playground import PlaygroundEndpointCreate, create_playground_endpoint
 from agno.cli.console import console
 from agno.cli.settings import agno_cli_settings
-from agno.models.anthropic import Claude
 from agno.models.google import Gemini
-from agno.playground import Playground
 from agno.tools.mcp import MCPTools
 from agno.utils.log import logger
 from fastapi import FastAPI
@@ -67,23 +65,42 @@ async def main():
     async with MCPTools(f"{sys.executable} -m codemcp.hot_reload_entry") as codemcp:
         # TODO: cli-ify the model
         agent = Agent(
-            #model=Claude(id="claude-3-7-sonnet-20250219"),
+            # model=Claude(id="claude-3-7-sonnet-20250219"),
             model=Gemini(id="gemini-2.5-pro-exp-03-25"),
             tools=[codemcp],
             instructions="",
             markdown=True,
             show_tool_calls=True,
         )
-        #agent.print_response("What tools do you have?", stream=True, show_full_reasoning=True, stream_intermediate_steps=True)
-        #return
-        playground = Playground(agents=[agent]).get_app()
-        await serve_playground_app_async(playground)
+        # agent.print_response("What tools do you have?", stream=True, show_full_reasoning=True, stream_intermediate_steps=True)
+        # return
+
+        # Comment out the playground code
+        # playground = Playground(agents=[agent]).get_app()
+        # await serve_playground_app_async(playground)
+
+        # Replace with a simple stdin loop
+        print("Enter your query (Ctrl+C to exit):")
+        while True:
+            try:
+                user_input = input("> ")
+                agent.print_response(
+                    user_input,
+                    stream=True,
+                    show_full_reasoning=True,
+                    stream_intermediate_steps=True,
+                )
+            except KeyboardInterrupt:
+                print("\nExiting...")
+                break
 
 
 if __name__ == "__main__":
     from agno.debug import enable_debug_mode
+
     enable_debug_mode()
     import logging
+
     logging.basicConfig(level=logging.DEBUG)
     logging.getLogger("httpx").setLevel(logging.DEBUG)  # For HTTP logging
     logging.getLogger("anthropic").setLevel(logging.DEBUG)

--- a/codemcp/agno.py
+++ b/codemcp/agno.py
@@ -61,6 +61,17 @@ async def serve_playground_app_async(
     await server.serve()
 
 
+# This function handles a single query
+async def process_query(agent, query):
+    """Process a single query with the agent."""
+    await agent.print_response(
+        query,
+        stream=True,
+        show_full_reasoning=True,
+        stream_intermediate_steps=True,
+    )
+
+
 async def main():
     async with MCPTools(f"{sys.executable} -m codemcp.hot_reload_entry") as codemcp:
         # TODO: cli-ify the model
@@ -79,24 +90,17 @@ async def main():
         # playground = Playground(agents=[agent]).get_app()
         # await serve_playground_app_async(playground)
 
-        # Replace with a simple async loop for stdin input
+        # Replace with a simple CLI input loop
         print("Enter your query (Ctrl+C to exit):")
-        while True:
-            try:
-                # Use asyncio to read from stdin in an async-friendly way
-                loop = asyncio.get_event_loop()
-                user_input = await loop.run_in_executor(None, lambda: input("> "))
+        try:
+            while True:
+                # Get input from user (non-async operation)
+                user_input = input("> ")
 
-                # Properly await the async print_response method
-                await agent.print_response(
-                    user_input,
-                    stream=True,
-                    show_full_reasoning=True,
-                    stream_intermediate_steps=True,
-                )
-            except KeyboardInterrupt:
-                print("\nExiting...")
-                break
+                # Process the query in an async way
+                await process_query(agent, user_input)
+        except KeyboardInterrupt:
+            print("\nExiting...")
 
 
 if __name__ == "__main__":

--- a/codemcp/agno.py
+++ b/codemcp/agno.py
@@ -79,12 +79,16 @@ async def main():
         # playground = Playground(agents=[agent]).get_app()
         # await serve_playground_app_async(playground)
 
-        # Replace with a simple stdin loop
+        # Replace with a simple async loop for stdin input
         print("Enter your query (Ctrl+C to exit):")
         while True:
             try:
-                user_input = input("> ")
-                agent.print_response(
+                # Use asyncio to read from stdin in an async-friendly way
+                loop = asyncio.get_event_loop()
+                user_input = await loop.run_in_executor(None, lambda: input("> "))
+
+                # Properly await the async print_response method
+                await agent.print_response(
                     user_input,
                     stream=True,
                     show_full_reasoning=True,

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -67,7 +67,9 @@ async def codemcp(
     subtool: str,
     *,
     path: str | None = None,
-    content: str | dict | None = None,  # Allow any type, will be serialized to string if needed
+    content: str
+    | dict
+    | None = None,  # Allow any type, will be serialized to string if needed
     old_string: str | None = None,
     new_string: str | None = None,
     offset: int | None = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #252
* #250
* __->__ #249
* #248
* #247
* #246
* #245

codemcp/agno.py

Comment this out

        playground = Playground(agents=[agent]).get_app()
        await serve_playground_app_async(playground)

And replace it with a simple loop that reads user input from stdin and then feeds it to agent.print_response(USER_INPUT, stream=True, show_full_reasoning=True, stream_intermediate_steps=True)

```git-revs
07d9020  (Base revision)
d245ee6  Replace playground with stdin loop
8ff5aa1  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 260-feat-replace-playground-with-stdin-loop-in-agno-py