### PR TITLE
fix: convert git directory check warning to error

### DIFF
--- a/codemcp/git_query.py
+++ b/codemcp/git_query.py
@@ -262,8 +262,11 @@ async def get_current_commit_hash(directory: str, short: bool = True) -> str | N
     Returns:
         The current commit hash if available, None otherwise
 
+    Raises:
+        NotADirectoryError: If the provided path is a file instead of a directory
+
     Note:
-        This function safely returns None if there are any issues getting the hash,
+        This function safely returns None for other issues getting the hash,
         rather than raising exceptions.
     """
     try:
@@ -287,6 +290,9 @@ async def get_current_commit_hash(directory: str, short: bool = True) -> str | N
         if result.returncode == 0:
             return str(result.stdout.strip())
         return None
+    except NotADirectoryError:
+        # Re-raise NotADirectoryError as a hard error
+        raise
     except Exception as e:
         logging.warning(
             f"Exception when getting current commit hash: {e!s}", exc_info=True

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -110,7 +110,9 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         try:
             await self.git_run(["init", "-b", "main"])
         except subprocess.CalledProcessError:
-            self.fail("git version is too old for tests! Please install a newer version of git.")
+            self.fail(
+                "git version is too old for tests! Please install a newer version of git."
+            )
         await self.git_run(["config", "user.email", "test@example.com"])
         await self.git_run(["config", "user.name", "Test User"])
 

--- a/e2e/test_git_query_file_path.py
+++ b/e2e/test_git_query_file_path.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+"""Tests for the get_current_commit_hash function when passed a file path."""
+
+import os
+import unittest
+
+from codemcp.git_query import get_current_commit_hash
+from codemcp.testing import MCPEndToEndTestCase
+
+
+class GitQueryFilePathTest(MCPEndToEndTestCase):
+    """Test that get_current_commit_hash raises a NotADirectoryError when passed a file path."""
+
+    async def test_file_path_raises_error(self):
+        """Test that passing a file path to get_current_commit_hash raises NotADirectoryError."""
+        # Create a test file in the temp dir
+        test_file_path = os.path.join(self.temp_dir.name, "test_file.txt")
+        with open(test_file_path, "w") as f:
+            f.write("Test content")
+
+        # Attempt to get current commit hash using a file path instead of directory
+        # This should raise a NotADirectoryError
+        with self.assertRaises(NotADirectoryError):
+            await get_current_commit_hash(test_file_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

We sometimes fail to get current commit hash. This is because we improperly pass a file rather than directory to the git command. Here is a representative warning:

2025-04-14 21:31:31,930 - root - WARNING - Exception when getting current commit hash: [Errno 20] Not a directory: '/Users/ezyang/Dev/codemcp/codemcp/agno.py'
Traceback (most recent call last):
  File "/Users/ezyang/Dev/codemcp/codemcp/git_query.py", line 279, in get_current_commit_hash
    result = await run_command(
             ^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/Dev/codemcp/codemcp/shell.py", line 73, in run_command
    process = await asyncio.create_subprocess_exec(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/asyncio/subprocess.py", line 224, in create_subprocess_exec
    transport, protocol = await loop.subprocess_exec(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 1756, in subprocess_exec
    transport = await self._make_subprocess_transport(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/asyncio/unix_events.py", line 211, in *make*subprocess_transport
    transp = _UnixSubprocessTransport(self, protocol, args, shell,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/asyncio/base_subprocess.py", line 36, in **init**
    self._start(args=args, shell=shell, stdin=stdin, stdout=stdout,
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/asyncio/unix_events.py", line 820, in _start
    self._proc = subprocess.Popen(
                 ^^^^^^^^^^^^^^^^^
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/subprocess.py", line 1028, in **init**
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/ezyang/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/subprocess.py", line 1963, in *execute*child
    raise child_exception_type(errno_num, err_msg, err_filename)
NotADirectoryError: [Errno 20] Not a directory: '/Users/ezyang/Dev/codemcp/codemcp/agno.py'

Convert this warning into a hard error, and add a test which triggers the failure. The test SHOULD fail. Halt when done so I can inspect, before we fix.

```git-revs
e4427af  (Base revision)
a6b4788  Convert file not directory warning to hard error
5646b1b  Add test for get_current_commit_hash with file path
e59e63c  Auto-commit format changes
HEAD     Auto-commit lint changes
```

codemcp-id: 265-fix-convert-git-directory-check-warning-to-error