### PR TITLE
feat: add config option to disable automatic Git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ Logs are written to `~/.codemcp/codemcp.log`. The log level can be set in a glob
 ```toml
 [logger]
 verbosity = "INFO"  # Can be DEBUG, INFO, WARNING, ERROR, or CRITICAL
+
+[git]
+enabled = true  # Set to false to disable all automatic Git operations
 ```
 
 Logging is not configurable on a per project basis, but this shouldn't matter

--- a/codemcp/config.py
+++ b/codemcp/config.py
@@ -20,6 +20,7 @@ __all__ = [
     "get_logger_verbosity",
     "get_logger_path",
     "get_line_endings_preference",
+    "git_operations_enabled",
 ]
 
 # Default configuration values
@@ -30,6 +31,9 @@ DEFAULT_CONFIG = {
     },
     "files": {
         "line_endings": None,  # Default to OS native or based on configs
+    },
+    "git": {
+        "enabled": True,  # By default, git operations are enabled
     },
 }
 
@@ -136,3 +140,14 @@ def get_line_endings_preference() -> str | None:
     """
     config = load_config()
     return config["files"]["line_endings"]
+
+
+def git_operations_enabled() -> bool:
+    """Check if Git operations are enabled in the configuration.
+
+    Returns:
+        Boolean indicating whether Git operations are enabled.
+        Default is True if not specified in the config.
+    """
+    config = load_config()
+    return config["git"]["enabled"]

--- a/codemcp/file_utils.py
+++ b/codemcp/file_utils.py
@@ -8,6 +8,7 @@ import anyio
 
 from .access import check_edit_permission
 from .async_file_utils import OpenTextMode
+from .config import git_operations_enabled
 from .git import commit_changes
 from .line_endings import apply_line_endings, normalize_to_lf
 
@@ -55,6 +56,9 @@ async def check_git_tracking_for_existing_file(
 ) -> tuple[bool, str | None]:
     """Check if an existing file is tracked by git. Skips check for non-existent files.
 
+    If Git operations are disabled in the configuration, this function will skip
+    all Git checks and return success.
+
     Args:
         file_path: The absolute path to the file
         chat_id: The unique ID to identify the chat session
@@ -69,6 +73,13 @@ async def check_git_tracking_for_existing_file(
 
     # Normalize the path with tilde expansion
     file_path = normalize_file_path(file_path)
+
+    # If Git operations are disabled, skip all Git checks
+    if not git_operations_enabled():
+        logging.debug(
+            "Git operations are disabled in config, skipping Git tracking check"
+        )
+        return True, None
 
     # Check if the file exists
     file_exists = os.path.exists(file_path)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

codemcp makes does Git commits to keep track of writes and edits it makes to files, as well as to snapshot state of repo before and after it runs commands. Add a configuration option to codemcprc that optionally disables all of this, so that we NEVER issue any git commands automatically.

```git-revs
76f826f  (Base revision)
eaef646  Add git.enabled to default configuration
d42c38c  Add git_operations_enabled function to check if Git operations are enabled
3d05ab9  Import git_operations_enabled from config
4211fdc  Add check for disabled Git operations in create_commit_reference
274fe31  Update commit_changes docstring to mention git operations disabled case
d0ad8d4  Add check for disabled Git operations in commit_changes
ed91c17  Import git_operations_enabled from config
55c638f  Update check_git_tracking_for_existing_file to handle disabled Git operations
fac57d5  Add missing logging import
e9f9ee1  Fix duplicate logging import
ad2a7d6  Add git.enabled config option to README
HEAD     Auto-commit format changes
```

codemcp-id: 274-feat-add-config-option-to-disable-automatic-git-co