### PR TITLE
feat: integrate autoformatting in WriteFile and EditFile commands

### DIFF
--- a/codemcp/code_command.py
+++ b/codemcp/code_command.py
@@ -231,12 +231,7 @@ async def run_formatter_without_commit(file_path: str) -> Tuple[bool, str]:
         Propagates any unexpected errors during formatting
     """
     # Get the project directory (repository root)
-    project_dir = os.path.dirname(file_path)
-    try:
-        project_dir = await get_repository_root(project_dir)
-    except (subprocess.SubprocessError, OSError, ValueError):
-        # Fall back to the directory containing the file if not in a git repo
-        pass
+    project_dir = await get_repository_root(project_dir)
 
     # Get the format command from config - this is the only expected failure mode
     format_command = get_command_from_config(project_dir, "format")

--- a/codemcp/code_command.py
+++ b/codemcp/code_command.py
@@ -231,7 +231,7 @@ async def run_formatter_without_commit(file_path: str) -> Tuple[bool, str]:
         Propagates any unexpected errors during formatting
     """
     # Get the project directory (repository root)
-    project_dir = await get_repository_root(project_dir)
+    project_dir = await get_repository_root(file_path)
 
     # Get the format command from config - this is the only expected failure mode
     format_command = get_command_from_config(project_dir, "format")

--- a/e2e/test_run_command.py
+++ b/e2e/test_run_command.py
@@ -60,7 +60,16 @@ def test_run_command_with_args(project_dir):
         f.write("test content")
 
     result = subprocess.run(
-        [sys.executable, "-m", "codemcp", "run", "list", test_file, "--path", project_dir],
+        [
+            sys.executable,
+            "-m",
+            "codemcp",
+            "run",
+            "list",
+            test_file,
+            "--path",
+            project_dir,
+        ],
         capture_output=True,
         text=True,
         check=True,
@@ -72,7 +81,15 @@ def test_run_command_error_exit_code(project_dir):
     """Test that error exit codes from the command are propagated."""
     # This should return a non-zero exit code
     process = subprocess.run(
-        [sys.executable, "-m", "codemcp", "run", "exit_with_error", "--path", project_dir],
+        [
+            sys.executable,
+            "-m",
+            "codemcp",
+            "run",
+            "exit_with_error",
+            "--path",
+            project_dir,
+        ],
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #278
* #277
* #276
* __->__ #273
* #274

We're going to integrate autoformatting into the WriteFile and EditFile commands. After doing the file write with these commands, run the "format" command (as defined by RunCommand) if it exists. You should NOT run the pre/post commit associated with RunCommand (because the formatting should be directly integrated with the edit/write), so make sure you hook into the run command infrastructure at the correct spot.

```git-revs
3f698ba  (Base revision)
c56fb59  Add run_formatter_without_commit to __all__
3a9183d  Add run_formatter_without_commit function to format a specific file without commit operations
13c9c8d  Add run_formatter_without_commit import to write_file.py
d5459f2  Add autoformatting to write_file_content function
4d419ac  Add run_formatter_without_commit import to edit_file.py
2ac534f  Add autoformatting to edit_file_content function
77cf162  Improve run_formatter_without_commit to handle different formatter types
HEAD     Auto-commit format changes
```

codemcp-id: 280-feat-integrate-autoformatting-in-writefile-and-edi