### PR TITLE
[FEATYURE] Make Git commands optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,14 +180,19 @@ Before beginning work on this feature, write a short haiku.  Do this only once.
 [commands]
 format = ["./run_format.sh"]
 test = ["./run_test.sh"]
+
+# Optional GitHub commands
+# ghstack = ["uv", "tool", "run", "ghstack"]
 ```
 
 The `project_prompt` will be loaded when you initialize the project in chats.
 
 The `commands` section allows you to configure commands for specific tools.  The
-names are told to the LLM, who will decide when it wants to run them.  You can add
-instructions how to use tools in the `project_prompt`; we also support a more verbose
-syntax where you can give specific instructions on a tool-by-tool basis:
+names are told to the LLM, who will decide when it wants to run them. GitHub-related
+commands (like `ghstack`) are completely optional and can be omitted if you don't use GitHub or
+don't need those features. You can add instructions how to use tools in the
+`project_prompt`; we also support a more verbose syntax where you can give specific
+instructions on a tool-by-tool basis:
 
 ```
 [commands.test]

--- a/codemcp.toml.example
+++ b/codemcp.toml.example
@@ -14,3 +14,12 @@ path = "~/.codemcp"
 # LF = Unix/Linux/macOS style (\n)
 # CRLF = Windows style (\r\n)
 line_endings = null  # null means auto-detect from .editorconfig, .gitattributes, or OS
+
+[commands]
+# Optional - Define commands to run within the project
+# format = ["./run_format.sh"]
+# lint = ["./run_lint.sh"]
+# typecheck = ["./run_typecheck.sh"]
+
+# Optional GitHub commands - these are not required for basic functionality
+# ghstack = ["uv", "tool", "run", "ghstack"]

--- a/codemcp/code_command.py
+++ b/codemcp/code_command.py
@@ -123,6 +123,10 @@ async def run_code_command(
             elif command_name == "formatting":
                 command_key = "format"
 
+            # For GitHub commands, make them optional and return a friendly message
+            if command_name == "ghstack":
+                return f"GitHub command '{command_key}' is not configured but is optional. You can add it to your codemcp.toml if needed."
+
             raise ValueError(f"No {command_key} command configured in codemcp.toml")
 
         # Check if directory is in a git repository

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -875,10 +875,18 @@ def run(command: str, args: tuple, path: str) -> None:
             config = tomli.load(f)
 
         if "commands" not in config or command not in config["commands"]:
-            click.echo(
-                f"Error: Command '{command}' not found in codemcp.toml", err=True
-            )
-            exit(1)  # Exit with error code 1
+            # Special handling for GitHub commands
+            if command == "ghstack":
+                click.echo(
+                    f"Note: GitHub command '{command}' is not configured but is optional. "
+                    f"You can add it to your codemcp.toml if needed.", err=True
+                )
+                return  # Exit gracefully without error code
+            else:
+                click.echo(
+                    f"Error: Command '{command}' not found in codemcp.toml", err=True
+                )
+                exit(1)  # Exit with error code 1
 
         cmd_config = config["commands"][command]
         cmd_list = None


### PR DESCRIPTION
```git-revs
acfb8e5  (Base revision)
d8a757c  Making GitHub command (ghstack) optional by returning a friendly message instead of raising an error
8e65c42  Updating the example config file to document that GitHub commands are optional
514eb01  Making GitHub commands optional in the CLI by providing a friendly message
17338ef  Adding a note about optional GitHub commands in the README's example configuration
HEAD     Clarifying in the README that GitHub commands are optional
```

codemcp-id: 6-init-set-up-initial-repository