### PR TITLE
refactor: make each subtool a top-level MCP tool

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -10,7 +10,7 @@ import click
 import pathspec
 import uvicorn
 from fastapi.middleware.cors import CORSMiddleware
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
@@ -32,6 +32,13 @@ from .tools.write_file import write_file_content
 
 # Initialize FastMCP server
 mcp = FastMCP("codemcp")
+
+
+# Helper function to get a chat_id from a Context
+def get_chat_id_from_context(ctx: Context) -> str:
+    # Generate a chat_id from the context
+    ctx_id = getattr(ctx, "id", None)
+    return f"{ctx_id}" if ctx_id else "default"
 
 
 # Helper function to get the current commit hash and append it to a result string
@@ -62,8 +69,8 @@ async def append_commit_hash(result: str, path: str | None) -> Tuple[str, str | 
     return result, current_hash
 
 
-# NB: If you edit this, also edit codemcp/tools/init_project.py
-@mcp.tool()
+# This function is kept for backward compatibility but is no longer directly exposed as a tool
+# Each subtool is individually exposed as a top-level MCP tool
 async def codemcp(
     subtool: str,
     *,

--- a/codemcp/tools/edit_file.py
+++ b/codemcp/tools/edit_file.py
@@ -9,6 +9,8 @@ import re
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Tuple
 
+from mcp.server.fastmcp import Context
+
 from ..code_command import run_formatter_without_commit
 from ..common import get_edit_snippet
 from ..file_utils import (
@@ -19,6 +21,7 @@ from ..file_utils import (
 )
 from ..git import commit_changes
 from ..line_endings import detect_line_endings
+from ..main import get_chat_id_from_context, mcp
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -26,6 +29,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "edit_file_content",
     "find_similar_file",
+    "edit_file",
 ]
 
 
@@ -805,3 +809,59 @@ async def edit_file_content(
         git_message = f"\n\nFailed to commit changes to git: {message}"
 
     return f"Successfully edited {full_file_path}\n\nHere's a snippet of the edited file:\n{snippet}{format_message}{git_message}"
+
+
+@mcp.tool()
+async def edit_file(
+    ctx: Context, file_path: str, old_string: str, new_string: str, description: str
+) -> str:
+    """This is a tool for editing files. For larger edits, use the WriteFile tool to overwrite files.
+    Provide a short description of the change.
+
+    Before using this tool:
+
+    1. Use the ReadFile tool to understand the file's contents and context
+
+    2. Verify the directory path is correct (only applicable when creating new files):
+       - Use the LS tool to verify the parent directory exists and is the correct location
+
+    To make a file edit, provide the following:
+    1. path: The absolute path to the file to modify (must be absolute, not relative)
+    2. old_string: The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace and indentation)
+    3. new_string: The edited text to replace the old_string
+
+    The tool will replace ONE occurrence of old_string with new_string in the specified file.
+
+    CRITICAL REQUIREMENTS FOR USING THIS TOOL:
+
+    1. UNIQUENESS: The old_string MUST uniquely identify the specific instance you want to change. This means:
+       - Include AT LEAST 3-5 lines of context BEFORE the change point
+       - Include AT LEAST 3-5 lines of context AFTER the change point
+       - Include all whitespace, indentation, and surrounding code exactly as it appears in the file
+
+    2. SINGLE INSTANCE: This tool can only change ONE instance at a time. If you need to change multiple instances:
+       - Make separate calls to this tool for each instance
+       - Each call must uniquely identify its specific instance using extensive context
+
+    3. VERIFICATION: Before using this tool:
+       - Check how many instances of the target text exist in the file
+       - If multiple instances exist, gather enough context to uniquely identify each one
+       - Plan separate tool calls for each instance
+
+    WARNING: If you do not follow these requirements:
+       - The tool will fail if old_string matches multiple locations
+       - The tool will fail if old_string doesn't match exactly (including whitespace)
+       - You may change the wrong instance if you don't include enough context
+
+    When making edits:
+       - Ensure the edit results in idiomatic, correct code
+       - Do not leave the code in a broken state
+       - Always use absolute file paths (starting with /)
+
+    Remember: when making multiple file edits in a row to the same file, you should prefer to send all edits in a single message with multiple calls to this tool, rather than multiple messages with a single call each.
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await edit_file_content(
+        file_path, old_string, new_string, None, description, chat_id
+    )

--- a/codemcp/tools/git_log.py
+++ b/codemcp/tools/git_log.py
@@ -2,10 +2,13 @@
 
 import logging
 import shlex
-from typing import Any
+from typing import Any, Optional
+
+from mcp.server.fastmcp import Context
 
 from ..common import normalize_file_path
 from ..git import is_git_repository
+from ..main import get_chat_id_from_context, mcp
 from ..shell import run_command
 
 __all__ = [
@@ -13,6 +16,7 @@ __all__ = [
     "render_result_for_assistant",
     "TOOL_NAME_FOR_PROMPT",
     "DESCRIPTION",
+    "git_log_tool",
 ]
 
 TOOL_NAME_FOR_PROMPT = "GitLog"
@@ -96,3 +100,22 @@ def render_result_for_assistant(output: dict[str, Any]) -> str:
         A formatted string representation of the results
     """
     return output.get("output", "")
+
+
+@mcp.tool()
+async def git_log_tool(ctx: Context, path: str, arguments: Optional[str] = None) -> str:
+    """Shows commit logs using git log.
+    This tool is read-only and safe to use with any arguments.
+    The arguments parameter should be a string and will be interpreted as space-separated
+    arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+    for arguments containing spaces, etc.).
+
+    Example:
+      git log --oneline -n 5  # Show the last 5 commits in oneline format
+      git log --author="John Doe" --since="2023-01-01"  # Show commits by an author since a date
+      git log -- path/to/file  # Show commit history for a specific file
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    result = await git_log(arguments, path, chat_id)
+    return result.get("resultForAssistant", "")

--- a/codemcp/tools/git_show.py
+++ b/codemcp/tools/git_show.py
@@ -2,10 +2,13 @@
 
 import logging
 import shlex
-from typing import Any
+from typing import Any, Optional
+
+from mcp.server.fastmcp import Context
 
 from ..common import normalize_file_path
 from ..git import is_git_repository
+from ..main import get_chat_id_from_context, mcp
 from ..shell import run_command
 
 __all__ = [
@@ -13,6 +16,7 @@ __all__ = [
     "render_result_for_assistant",
     "TOOL_NAME_FOR_PROMPT",
     "DESCRIPTION",
+    "git_show_tool",
 ]
 
 TOOL_NAME_FOR_PROMPT = "GitShow"
@@ -98,3 +102,26 @@ def render_result_for_assistant(output: dict[str, Any]) -> str:
         A formatted string representation of the results
     """
     return output.get("output", "")
+
+
+@mcp.tool()
+async def git_show_tool(
+    ctx: Context, path: str, arguments: Optional[str] = None
+) -> str:
+    """Shows various types of objects (commits, tags, trees, blobs) using git show.
+    This tool is read-only and safe to use with any arguments.
+    The arguments parameter should be a string and will be interpreted as space-separated
+    arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+    for arguments containing spaces, etc.).
+
+    Example:
+      git show  # Show the most recent commit
+      git show a1b2c3d  # Show a specific commit by hash
+      git show HEAD~3  # Show the commit 3 before HEAD
+      git show v1.0  # Show a tag
+      git show HEAD:path/to/file  # Show a file from a specific commit
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    result = await git_show(arguments, path, chat_id)
+    return result.get("resultForAssistant", "")

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -6,12 +6,16 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from mcp.server.fastmcp import Context
+
 from ..common import normalize_file_path
+from ..main import get_chat_id_from_context, mcp
 
 __all__ = [
     "glob_files",
     "glob",
     "render_result_for_assistant",
+    "glob_tool",
 ]
 
 # Define constants
@@ -188,3 +192,18 @@ async def glob_files(
     output["resultForAssistant"] = render_result_for_assistant(output)
 
     return output
+
+
+@mcp.tool()
+async def glob_tool(ctx: Context, pattern: str, path: str) -> str:
+    """Fast file pattern matching tool that works with any codebase size
+    Supports glob patterns like "**/*.js" or "src/**/*.ts"
+    Returns matching file paths sorted by modification time
+    Use this tool when you need to find files by name patterns
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    result = await glob_files(pattern, path, MAX_RESULTS, 0, chat_id)
+    return result.get(
+        "resultForAssistant", f"Found {result.get('numFiles', 0)} file(s)"
+    )

--- a/codemcp/tools/ls.py
+++ b/codemcp/tools/ls.py
@@ -4,9 +4,12 @@ import asyncio
 import os
 from typing import List, Optional
 
+from mcp.server.fastmcp import Context
+
 from ..access import check_edit_permission
 from ..common import normalize_file_path
 from ..git import is_git_repository
+from ..main import get_chat_id_from_context, mcp
 
 __all__ = [
     "ls_directory",
@@ -16,6 +19,7 @@ __all__ = [
     "create_file_tree",
     "print_tree",
     "MAX_FILES",
+    "ls",
 ]
 
 MAX_FILES = 1000
@@ -231,3 +235,13 @@ def print_tree(
             result += print_tree(node.children, level + 1, f"{prefix}  ", cwd)
 
     return result
+
+
+@mcp.tool()
+async def ls(ctx: Context, file_path: str) -> str:
+    """Lists files and directories in a given path. The path parameter must be an absolute path, not a relative path.
+    You should generally prefer the Glob and Grep tools, if you know which directories to search.
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await ls_directory(file_path, chat_id)

--- a/codemcp/tools/mv.py
+++ b/codemcp/tools/mv.py
@@ -4,12 +4,16 @@ import logging
 import os
 import pathlib
 
+from mcp.server.fastmcp import Context
+
 from ..common import normalize_file_path
 from ..git import commit_changes, get_repository_root
+from ..main import get_chat_id_from_context, mcp
 from ..shell import run_command
 
 __all__ = [
     "mv_file",
+    "mv_tool",
 ]
 
 
@@ -133,3 +137,25 @@ async def mv_file(
         return f"Successfully moved file from {source_rel_path} to {target_rel_path}."
     else:
         return f"File was moved from {source_rel_path} to {target_rel_path} but failed to commit: {commit_message}"
+
+
+@mcp.tool()
+async def mv_tool(
+    ctx: Context, source_path: str, target_path: str, description: str
+) -> str:
+    """Moves a file using git mv and commits the change.
+    Provide a short description of why the file is being moved.
+
+    Before using this tool:
+    1. Ensure the source file exists and is tracked by git
+    2. Ensure the target directory exists within the git repository
+    3. Provide a meaningful description of why the file is being moved
+
+    Args:
+        source_path: The path to the file to move (can be relative to the project root or absolute)
+        target_path: The destination path where the file should be moved to (can be relative to the project root or absolute)
+        description: Short description of why the file is being moved
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await mv_file(source_path, target_path, description, chat_id)

--- a/codemcp/tools/read_file.py
+++ b/codemcp/tools/read_file.py
@@ -3,6 +3,8 @@
 import os
 from typing import List
 
+from mcp.server.fastmcp import Context
+
 from ..common import (
     MAX_LINE_LENGTH,
     MAX_LINES_TO_READ,
@@ -10,10 +12,12 @@ from ..common import (
     normalize_file_path,
 )
 from ..git_query import find_git_root
+from ..main import get_chat_id_from_context, mcp
 from ..rules import get_applicable_rules_content
 
 __all__ = [
     "read_file_content",
+    "read_file",
 ]
 
 
@@ -106,3 +110,18 @@ async def read_file_content(
         content += get_applicable_rules_content(repo_root, full_file_path)
 
     return content
+
+
+@mcp.tool()
+async def read_file(
+    ctx: Context, file_path: str, offset: int | None = None, limit: int | None = None
+) -> str:
+    """Reads a file from the local filesystem. The path parameter must be an absolute path, not a relative path.
+    By default, it reads up to 1000 lines starting from the beginning of the file. You can optionally specify a
+    line offset and limit (especially handy for long files), but it's recommended to read the whole file by not
+    providing these parameters. Any lines longer than 1000 characters will be truncated. For image files, the tool
+    will display the image for you.
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await read_file_content(file_path, offset, limit, chat_id)

--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -4,12 +4,16 @@ import logging
 import os
 import pathlib
 
+from mcp.server.fastmcp import Context
+
 from ..common import normalize_file_path
 from ..git import commit_changes, get_repository_root
+from ..main import get_chat_id_from_context, mcp
 from ..shell import run_command
 
 __all__ = [
     "rm_file",
+    "rm_tool",
 ]
 
 
@@ -94,3 +98,21 @@ async def rm_file(
         return f"Successfully removed file {rel_path}."
     else:
         return f"File {rel_path} was removed but failed to commit: {commit_message}"
+
+
+@mcp.tool()
+async def rm_tool(ctx: Context, path: str, description: str) -> str:
+    """Removes a file using git rm and commits the change.
+    Provide a short description of why the file is being removed.
+
+    Before using this tool:
+    1. Ensure the file exists and is tracked by git
+    2. Provide a meaningful description of why the file is being removed
+
+    Args:
+        path: The path to the file to remove (can be relative to the project root or absolute)
+        description: Short description of why the file is being removed
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await rm_file(path, description, chat_id)

--- a/codemcp/tools/run_command.py
+++ b/codemcp/tools/run_command.py
@@ -3,10 +3,14 @@
 import shlex
 from typing import Optional
 
+from mcp.server.fastmcp import Context
+
 from ..code_command import get_command_from_config, run_code_command
+from ..main import get_chat_id_from_context, mcp
 
 __all__ = [
     "run_command",
+    "run_command_tool",
 ]
 
 
@@ -44,3 +48,23 @@ async def run_command(
     return await run_code_command(
         project_dir, command, actual_command, f"Auto-commit {command} changes", chat_id
     )
+
+
+@mcp.tool()
+async def run_command_tool(
+    ctx: Context, path: str, command: str, arguments: Optional[str] = None
+) -> str:
+    """Runs a command. This does NOT support arbitrary code execution, ONLY call
+    with this set of valid commands: format, lint, ghstack, typecheck, test, accept
+    The arguments parameter should be a string and will be interpreted as space-separated
+    arguments using shell-style tokenization (spaces separate arguments, quotes can be used
+    for arguments containing spaces, etc.).
+
+    Command documentation:
+    - test: Accepts a pytest-style test selector as an argument to run a specific test.
+    - accept: Updates expecttest failing tests with their new values, akin to running with EXPECTTEST_ACCEPT=1.
+      Accepts a pytest-style test selector as an argument to run a specific test.
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await run_command(path, command, arguments, chat_id)

--- a/codemcp/tools/think.py
+++ b/codemcp/tools/think.py
@@ -2,8 +2,13 @@
 
 import logging
 
+from mcp.server.fastmcp import Context
+
+from ..main import get_chat_id_from_context, mcp
+
 __all__ = [
     "think",
+    "think_tool",
 ]
 
 
@@ -22,3 +27,13 @@ async def think(thought: str, chat_id: str | None = None) -> str:
 
     # Return a simple confirmation message
     return f"Thought logged: {thought}"
+
+
+@mcp.tool()
+async def think_tool(ctx: Context, thought: str) -> str:
+    """Use the tool to think about something. It will not obtain new information or change the database,
+    but just append the thought to the log. Use it when complex reasoning or some cache memory is needed.
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await think(thought, chat_id)

--- a/codemcp/tools/user_prompt.py
+++ b/codemcp/tools/user_prompt.py
@@ -3,11 +3,15 @@
 import logging
 import os
 
+from mcp.server.fastmcp import Context
+
 from ..git_query import find_git_root
+from ..main import get_chat_id_from_context, mcp
 from ..rules import get_applicable_rules_content
 
 __all__ = [
     "user_prompt",
+    "record_user_prompt",
 ]
 
 
@@ -37,3 +41,15 @@ async def user_prompt(user_text: str, chat_id: str | None = None) -> str:
         result += get_applicable_rules_content(repo_root)
 
     return result
+
+
+@mcp.tool()
+async def record_user_prompt(ctx: Context, user_prompt: str) -> str:
+    """Records the user's verbatim prompt text for each interaction after the initial one.
+    You should call this tool with the user's exact message at the beginning of each response.
+    This tool must be called in every response except for the first one where InitProject was used.
+    Do NOT include documents or other attachments, only the text prompt.
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await user_prompt(user_prompt, chat_id)

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -3,6 +3,8 @@
 import logging
 import os
 
+from mcp.server.fastmcp import Context
+
 from ..code_command import run_formatter_without_commit
 from ..file_utils import (
     check_file_path_and_permissions,
@@ -11,9 +13,11 @@ from ..file_utils import (
 )
 from ..git import commit_changes
 from ..line_endings import detect_line_endings, detect_repo_line_endings
+from ..main import get_chat_id_from_context, mcp
 
 __all__ = [
     "write_file_content",
+    "write_file",
 ]
 
 
@@ -84,3 +88,22 @@ async def write_file_content(
         git_message = f"\nFailed to commit changes to git: {message}"
 
     return f"Successfully wrote to {file_path}{format_message}{git_message}"
+
+
+@mcp.tool()
+async def write_file(
+    ctx: Context, file_path: str, content: str, description: str
+) -> str:
+    """Write a file to the local filesystem. Overwrites the existing file if there is one.
+    Provide a short description of the change.
+
+    Before using this tool:
+
+    1. Use the ReadFile tool to understand the file's contents and context
+
+    2. Directory Verification (only applicable when creating new files):
+       - Use the LS tool to verify the parent directory exists and is the correct location
+    """
+    # Get chat ID from context
+    chat_id = get_chat_id_from_context(ctx)
+    return await write_file_content(file_path, content, description, chat_id)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

In codemcp/multi_entry.py there is a POC for how to have each of the SubTools as a dedicated top level MCP tool. Let's change codemcp/main.py so we apply this for all subtools.
We must worry about BC for the codemcp function in codemcp/main.py. We will remove the @mcp.tool decorator but leave the function so tests don't break (we will refactor the tests later.) Let's annotate @mcp.tool in each codemcp/tools/ file individually. In codemcp/tools/init_project.py there is a system_prompt which documents the tools. These should be moved into the docstring of each mcp.tool declaration. The non-tool system prompt should continue to emitted from InitProject tool.

```git-revs
65a2e52  (Base revision)
6ebb292  Add get_chat_id_from_context helper function
1d46ff5  Add Context import from mcp.server.fastmcp
7a84952  Remove @mcp.tool decorator but keep function for backward compatibility
804c644  Add imports for Context, mcp, and get_chat_id_from_context
a6bcd81  Add read_file to __all__
d15b9c9  Add read_file top-level MCP tool
f522500  Update imports and __all__ in write_file.py
7776dc8  Add write_file top-level MCP tool
f410f72  Update imports and __all__ in edit_file.py
cd5539c  Add edit_file top-level MCP tool
9e4d755  Update imports and __all__ in ls.py
5453bbe  Add ls top-level MCP tool
7749c32  Update imports and __all__ in user_prompt.py
187fd92  Add record_user_prompt top-level MCP tool
c434dd7  Update imports and __all__ in init_project.py
48ded01  Remove tool documentation from system_prompt since it's now in docstrings
84ffd44  Add initialize_project top-level MCP tool
4806639  Update imports and __all__ in think.py
8bc128b  Add think_tool top-level MCP tool
2de5b3e  Update imports and __all__ in grep.py
fafd43c  Add grep top-level MCP tool
eea2b5b  Update imports and __all__ in glob.py
be20f9d  Add glob_tool top-level MCP tool
00ae84a  Update imports and __all__ in chmod.py
05cfef6  Add chmod_tool top-level MCP tool
e3e2e9c  Update imports and __all__ in run_command.py
8c34db2  Add run_command_tool top-level MCP tool
b498258  Update imports and __all__ in rm.py
2e450af  Add rm_tool top-level MCP tool
1219e18  Update imports and __all__ in mv.py
5814b30  Add mv_tool top-level MCP tool
f8f4783  Update imports and __all__ in git_log.py
a8483a0  Add git_log_tool top-level MCP tool
21dc859  Update imports and __all__ in git_diff.py
83a09c6  Add git_diff_tool top-level MCP tool
e92b032  Update imports and __all__ in git_show.py
bb57af2  Add git_show_tool top-level MCP tool
6e7b6bf  Update imports and __all__ in git_blame.py
20eb2a5  Add git_blame_tool top-level MCP tool
HEAD     Auto-commit lint changes
```

codemcp-id: 292-refactor-make-each-subtool-a-top-level-mcp-tool