### PR TITLE
fix: make server exit immediately on Ctrl+C

### DIFF
--- a/codemcp/multi_entry.py
+++ b/codemcp/multi_entry.py
@@ -80,6 +80,22 @@ async def init_project_tool(
 
 
 def main():
+    # Set up a signal handler to exit immediately on Ctrl+C
+    import signal
+    import os
+    import logging
+
+    def handle_exit(sig, frame):
+        logging.info(
+            "Received shutdown signal - exiting immediately without waiting for connections"
+        )
+        os._exit(0)
+
+    # Register for SIGINT (Ctrl+C) and SIGTERM
+    signal.signal(signal.SIGINT, handle_exit)
+    signal.signal(signal.SIGTERM, handle_exit)
+
+    # Run the MCP server
     mcp.run()
 
 

--- a/codemcp/multi_entry.py
+++ b/codemcp/multi_entry.py
@@ -95,7 +95,7 @@ def main():
     signal.signal(signal.SIGINT, handle_exit)
     signal.signal(signal.SIGTERM, handle_exit)
 
-    # Run the MCP server
+    # The signal handler will force-exit the process when Ctrl+C is pressed
     mcp.run()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #290
* #289

When I control-C codemcp serve uvicorn server it hangs on shutting down:

2025-05-05 10:40:02,271 - sse_starlette.sse - DEBUG - chunk: b'event: message\r\ndata: {"jsonrpc":"2.0","id":4,"result":{"prompts":[]}}\r\n\r\n'
^CINFO:     Shutting down
INFO:     Waiting for connections to close. (CTRL+C to force quit)

Force quite does not work. Let's get rid of all of the orderly shutdown and unceremoniously terminate all the connections.

```git-revs
47aa12b  (Base revision)
3a386f3  Make server exit immediately on Ctrl+C instead of waiting for connections to close
6b4aa15  Make agno server exit immediately on Ctrl+C instead of waiting for connections to close
4c9fb8d  Add immediate exit on Ctrl+C to the default run function
HEAD     Add immediate exit on Ctrl+C to the multi_entry.py module
```

codemcp-id: 294-fix-make-server-exit-immediately-on-ctrl-c