### PR TITLE
refactor: Bypass codemcp.main.codemcp in tests

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -214,7 +214,9 @@ async def codemcp(
             # Accept either new_string or new_str (prefer new_string if both are provided)
             new_content = new_string or new_str
 
-            result = await edit_file(path, old_content, new_content, None, description, chat_id, commit_hash)
+            result = await edit_file(
+                path, old_content, new_content, None, description, chat_id, commit_hash
+            )
             return result
 
         if subtool == "LS":
@@ -276,7 +278,9 @@ async def codemcp(
                 raise ValueError("path is required for Glob subtool")
 
             try:
-                result_string = await glob(pattern, path, limit, offset, chat_id, commit_hash)
+                result_string = await glob(
+                    pattern, path, limit, offset, chat_id, commit_hash
+                )
                 return result_string
             except Exception as e:
                 logging.error(f"Error in Glob subtool: {e}", exc_info=True)
@@ -307,7 +311,9 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for MV subtool")
 
-            result = await mv(source_path, target_path, description, chat_id, commit_hash)
+            result = await mv(
+                source_path, target_path, description, chat_id, commit_hash
+            )
             return result
 
         if subtool == "Think":

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -182,7 +182,7 @@ async def codemcp(
             if path is None:
                 raise ValueError("path is required for ReadFile subtool")
 
-            result = await read_file(path, offset, limit, chat_id, commit_hash)
+            result = await read_file(**provided_params)
             return result
 
         if subtool == "WriteFile":
@@ -193,7 +193,7 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for WriteFile subtool")
 
-            result = await write_file(path, content, description, chat_id, commit_hash)
+            result = await write_file(**provided_params)
             return result
 
         if subtool == "EditFile":
@@ -209,21 +209,14 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for EditFile subtool")
 
-            # Accept either old_string or old_str (prefer old_string if both are provided)
-            old_content = old_string or old_str
-            # Accept either new_string or new_str (prefer new_string if both are provided)
-            new_content = new_string or new_str
-
-            result = await edit_file(
-                path, old_content, new_content, None, description, chat_id, commit_hash
-            )
+            result = await edit_file(**provided_params)
             return result
 
         if subtool == "LS":
             if path is None:
                 raise ValueError("path is required for LS subtool")
 
-            result = await ls(path, chat_id, commit_hash)
+            result = await ls(**provided_params)
             return result
 
         if subtool == "InitProject":
@@ -233,14 +226,19 @@ async def codemcp(
                 raise ValueError("user_prompt is required for InitProject subtool")
             if subject_line is None:
                 raise ValueError("subject_line is required for InitProject subtool")
-            if reuse_head_chat_id is None:
-                reuse_head_chat_id = (
-                    False  # Default value in main.py only, not in the implementation
-                )
 
-            return await init_project(
-                path, user_prompt, subject_line, reuse_head_chat_id
-            )
+            # Handle parameter naming differences with adapter pattern in the central point
+            if "path" in provided_params and "directory" not in provided_params:
+                provided_params["directory"] = provided_params.pop("path")
+
+            # Ensure reuse_head_chat_id has a default value
+            if (
+                "reuse_head_chat_id" not in provided_params
+                or provided_params["reuse_head_chat_id"] is None
+            ):
+                provided_params["reuse_head_chat_id"] = False
+
+            return await init_project(**provided_params)
 
         if subtool == "RunCommand":
             # When is something a command as opposed to a subtool?  They are
@@ -255,7 +253,11 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for RunCommand subtool")
 
-            result = await run_command(path, command, arguments, chat_id, commit_hash)
+            # Handle parameter naming differences with adapter pattern in the central point
+            if "path" in provided_params and "project_dir" not in provided_params:
+                provided_params["project_dir"] = provided_params.pop("path")
+
+            result = await run_command(**provided_params)
             return result
 
         if subtool == "Grep":
@@ -265,7 +267,7 @@ async def codemcp(
                 raise ValueError("path is required for Grep subtool")
 
             try:
-                result_string = await grep(pattern, path, include, chat_id, commit_hash)
+                result_string = await grep(**provided_params)
                 return result_string
             except Exception as e:
                 logging.error(f"Error in Grep subtool: {e}", exc_info=True)
@@ -278,9 +280,7 @@ async def codemcp(
                 raise ValueError("path is required for Glob subtool")
 
             try:
-                result_string = await glob(
-                    pattern, path, limit, offset, chat_id, commit_hash
-                )
+                result_string = await glob(**provided_params)
                 return result_string
             except Exception as e:
                 logging.error(f"Error in Glob subtool: {e}", exc_info=True)
@@ -294,7 +294,7 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for RM subtool")
 
-            result = await rm(path, description, chat_id, commit_hash)
+            result = await rm(**provided_params)
             return result
 
         if subtool == "MV":
@@ -311,16 +311,14 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for MV subtool")
 
-            result = await mv(
-                source_path, target_path, description, chat_id, commit_hash
-            )
+            result = await mv(**provided_params)
             return result
 
         if subtool == "Think":
             if thought is None:
                 raise ValueError("thought is required for Think subtool")
 
-            result = await think(thought, chat_id, commit_hash)
+            result = await think(**provided_params)
             return result
 
         if subtool == "Chmod":
@@ -331,7 +329,7 @@ async def codemcp(
             if chat_id is None:
                 raise ValueError("chat_id is required for Chmod subtool")
 
-            result_string = await chmod(path, mode, chat_id, commit_hash)
+            result_string = await chmod(**provided_params)
             return result_string
 
     except Exception:

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -231,24 +231,7 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         elif subtool == "EditFile":
             from codemcp.tools.edit_file import edit_file
 
-            # Handle old_str/new_str vs old_string/new_string compatibility
-            old_content = kwargs.get("old_string") or kwargs.get("old_str")
-            new_content = kwargs.get("new_string") or kwargs.get("new_str")
-            # Remove the old parameters since we're using them directly
-            kwargs_copy = {
-                k: v
-                for k, v in kwargs.items()
-                if k not in ("old_string", "new_string", "old_str", "new_str")
-            }
-            return await edit_file(
-                kwargs["path"],
-                old_content,
-                new_content,
-                None,
-                kwargs_copy.get("description"),
-                kwargs_copy.get("chat_id"),
-                kwargs_copy.get("commit_hash"),
-            )
+            return await edit_file(**kwargs)
 
         elif subtool == "LS":
             from codemcp.tools.ls import ls
@@ -259,15 +242,11 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
             from codemcp.tools.init_project import init_project
 
             # Convert 'path' parameter to 'directory' as expected by init_project
-            # Also ensure reuse_head_chat_id parameter is provided (defaults to False)
             if "path" in kwargs:
+                kwargs = kwargs.copy()  # Make a copy to avoid modifying the original
                 directory = kwargs.pop("path")
-                if "reuse_head_chat_id" not in kwargs:
-                    kwargs["reuse_head_chat_id"] = False
                 return await init_project(directory=directory, **kwargs)
             else:
-                if "reuse_head_chat_id" not in kwargs:
-                    kwargs["reuse_head_chat_id"] = False
                 return await init_project(**kwargs)
 
         elif subtool == "RunCommand":
@@ -275,6 +254,7 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
 
             # Convert 'path' parameter to 'project_dir' as expected by run_command
             if "path" in kwargs:
+                kwargs = kwargs.copy()  # Make a copy to avoid modifying the original
                 project_dir = kwargs.pop("path")
                 return await run_command(project_dir=project_dir, **kwargs)
             else:

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -117,9 +117,9 @@ async def glob(
         else:
             output = f"Found {total_matches} files matching '{pattern}' in {path}"
             if offset_val > 0 or total_matches > offset_val + limit_val:
-                output += f" (showing {offset_val+1}-{min(offset_val+limit_val, total_matches)} of {total_matches})"
+                output += f" (showing {offset_val + 1}-{min(offset_val + limit_val, total_matches)} of {total_matches})"
             output += ":\n\n"
-            
+
             for match in matches:
                 output += f"{match}\n"
 

--- a/codemcp/tools/write_file.py
+++ b/codemcp/tools/write_file.py
@@ -71,9 +71,7 @@ async def write_file(
         raise ValueError(error_message)
 
     # Check git tracking for existing files
-    is_tracked, track_error = await check_git_tracking_for_existing_file(
-        path, chat_id
-    )
+    is_tracked, track_error = await check_git_tracking_for_existing_file(path, chat_id)
     if not is_tracked:
         raise ValueError(track_error)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #297
* #296
* __->__ #295
* #294
* #293
* #292
* #291

We recently refactored all codemcp/tools to have uniform naming convention according to subtool. Now I want all testing code to bypass codemcp.main.codemcp and instead directly call the function in main. We mostly need to update call_tool_assert_success. For BC, let's not change the signature; instead, we'll lookup the correct module.function using the passed subtool argument, and otherwise call the function with the same kwargs that codemcp would have been called with (we also recently updated all of the subtools to have exactly the same kwargs). Make this change and then run tests.

```git-revs
74f6121  (Base revision)
44aa7b8  Refactor call_tool_assert_success to bypass codemcp.main.codemcp and directly call subtool functions
0420dfe  Refactor call_tool_assert_error to bypass codemcp.main.codemcp and directly call subtool functions
db323cc  Update get_chat_id to directly call init_project instead of codemcp.main.codemcp
370d10f  Snapshot before auto-test
2102f1f  Fix parameter name for init_project (using 'directory' instead of 'path')
395a8a9  Fix InitProject parameter handling to convert 'path' to 'directory'
addb355  Fix InitProject parameter handling in call_tool_assert_error
334373d  Fix RunCommand parameter handling in call_tool_assert_error
5503501  Fix RunCommand parameter handling in call_tool_assert_success
54063b6  Fix InitProject to ensure reuse_head_chat_id parameter is provided
HEAD     Fix InitProject to ensure reuse_head_chat_id parameter is provided in call_tool_assert_error
```

codemcp-id: 295-refactor-bypass-codemcp-main-codemcp-in-tests