### PR TITLE
fix: Fix tests after refactoring to bypass codemcp.main.codemcp

### DIFF
--- a/codemcp/agno.py
+++ b/codemcp/agno.py
@@ -25,9 +25,10 @@ async def serve_playground_app_async(
     prefix="/v1",
     **kwargs,
 ):
-    import uvicorn
-    import signal
     import os
+    import signal
+
+    import uvicorn
 
     try:
         create_playground_endpoint(

--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import click
 import pathspec
@@ -14,8 +14,6 @@ from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
-from .common import normalize_file_path
-from .git_query import get_current_commit_hash
 from .tools.chmod import chmod
 from .tools.edit_file import edit_file
 from .tools.glob import glob
@@ -839,8 +837,8 @@ def run() -> None:
     configure_logging()
 
     # Set up a signal handler to exit immediately on Ctrl+C
-    import signal
     import os
+    import signal
 
     def handle_exit(sig, frame):
         logging.info(
@@ -887,8 +885,8 @@ def serve(host: str, port: int, cors_origin: List[str]) -> None:
 
     app = create_sse_app(allowed_origins)
 
-    import signal
     import os
+    import signal
 
     # Register a custom signal handler that will take precedence and exit immediately
     def handle_exit(sig, frame):

--- a/codemcp/tools/glob.py
+++ b/codemcp/tools/glob.py
@@ -3,7 +3,7 @@
 import fnmatch
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from ..common import normalize_file_path
 from ..git import is_git_repository
@@ -106,10 +106,6 @@ async def glob(
         matches = matches[offset_val : offset_val + limit_val]
 
         # Create the result dictionary
-        result_dict = {
-            "files": matches,
-            "total": total_matches,
-        }
 
         # Format the results
         if not matches:

--- a/codemcp/tools/grep.py
+++ b/codemcp/tools/grep.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import subprocess
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict
 
 from ..common import normalize_file_path
 from ..git import is_git_repository

--- a/codemcp/tools/mv.py
+++ b/codemcp/tools/mv.py
@@ -3,12 +3,9 @@
 import logging
 import os
 import pathlib
-import shutil
-from typing import Optional
 
-from ..access import check_edit_permission
 from ..common import normalize_file_path
-from ..git import commit_changes, get_repository_root, is_git_repository
+from ..git import commit_changes, get_repository_root
 from ..shell import run_command
 from .commit_utils import append_commit_hash
 

--- a/codemcp/tools/rm.py
+++ b/codemcp/tools/rm.py
@@ -48,7 +48,7 @@ async def rm(
         raise ValueError(permission_message)
 
     # Determine if it's a file or directory
-    is_dir = os.path.isdir(full_path)
+    os.path.isdir(full_path)
 
     # Get git repository root
     git_root = await get_repository_root(os.path.dirname(full_path))

--- a/tests/test_edit_file_string_matching.py
+++ b/tests/test_edit_file_string_matching.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
+
 from expecttest import TestCase
 
 from codemcp.tools.edit_file import (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Run and fix tests.

```git-revs
2e1cfd3  (Base revision)
20f692c  Fix InitProject handling in _dispatch_to_subtool to ensure reuse_head_chat_id parameter is always provided
85a3c4d  Update get_chat_id to use _dispatch_to_subtool for consistency with other test methods
HEAD     Auto-commit lint changes
```

codemcp-id: 296-fix-fix-tests-after-refactoring-to-bypass-codemcp-