### PR TITLE
fix: prevent ruff from pruning tool imports in main.py

### DIFF
--- a/codemcp/main.py
+++ b/codemcp/main.py
@@ -14,18 +14,18 @@ from starlette.applications import Starlette
 from starlette.routing import Mount
 
 from .mcp import mcp
-from .tools.chmod import chmod
-from .tools.edit_file import edit_file
-from .tools.glob import glob
-from .tools.grep import grep
-from .tools.init_project import init_project
-from .tools.ls import ls
-from .tools.mv import mv
-from .tools.read_file import read_file
-from .tools.rm import rm
-from .tools.run_command import run_command
-from .tools.think import think
-from .tools.write_file import write_file
+from .tools.chmod import chmod  # noqa: F401
+from .tools.edit_file import edit_file  # noqa: F401
+from .tools.glob import glob  # noqa: F401
+from .tools.grep import grep  # noqa: F401
+from .tools.init_project import init_project  # noqa: F401
+from .tools.ls import ls  # noqa: F401
+from .tools.mv import mv  # noqa: F401
+from .tools.read_file import read_file  # noqa: F401
+from .tools.rm import rm  # noqa: F401
+from .tools.run_command import run_command  # noqa: F401
+from .tools.think import think  # noqa: F401
+from .tools.write_file import write_file  # noqa: F401
 
 
 def get_files_respecting_gitignore(dir_path: Path, pattern: str = "**/*") -> List[Path]:

--- a/codemcp/testing.py
+++ b/codemcp/testing.py
@@ -349,7 +349,9 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
                     "Session cannot be None when in_process=False"
                 )
                 # Convert subtool name to lowercase snake case (e.g., ReadFile -> read_file)
-                subtool_snake_case = ''.join(['_' + c.lower() if c.isupper() else c for c in subtool]).lstrip('_')
+                subtool_snake_case = "".join(
+                    ["_" + c.lower() if c.isupper() else c for c in subtool]
+                ).lstrip("_")
                 # Call the subtool directly instead of calling the codemcp tool
                 result = await session.call_tool(subtool_snake_case, kwargs)  # type: ignore
                 self.assertTrue(result.isError, result)
@@ -405,7 +407,9 @@ class MCPEndToEndTestCase(TestCase, unittest.IsolatedAsyncioTestCase):
         else:
             assert session is not None, "Session cannot be None when in_process=False"
             # Convert subtool name to lowercase snake case (e.g., ReadFile -> read_file)
-            subtool_snake_case = ''.join(['_' + c.lower() if c.isupper() else c for c in subtool]).lstrip('_')
+            subtool_snake_case = "".join(
+                ["_" + c.lower() if c.isupper() else c for c in subtool]
+            ).lstrip("_")
             # Call the subtool directly instead of calling the codemcp tool
             result = await session.call_tool(subtool_snake_case, kwargs)  # type: ignore
             self.assertFalse(result.isError, result)

--- a/codemcp/tools/init_project.py
+++ b/codemcp/tools/init_project.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 import tomli
 
-from ..common import MAX_LINE_LENGTH, MAX_LINES_TO_READ, normalize_file_path
+from ..common import normalize_file_path
 from ..git import get_repository_root, is_git_repository
 from ..mcp import mcp
 
@@ -219,7 +219,6 @@ async def init_project(
         )
 
         project_prompt = ""
-        command_help = ""
         command_docs: Dict[str, str] = {}
         rules_config: Dict[str, Any] = {}
 
@@ -239,7 +238,7 @@ async def init_project(
 
             # Extract commands and their documentation
             command_list = rules_config.get("commands", {})
-            command_help = ", ".join(command_list.keys())
+            ", ".join(command_list.keys())
 
             # Process command documentation
             for cmd_name, cmd_config in command_list.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Each of the tools imports in codemcp/main.py must not be pruned by ruff as they have side effects, add appropriate noqa to them

```git-revs
3724281  (Base revision)
HEAD     Add noqa comments to tool imports to prevent ruff from pruning them as they have side effects
```

codemcp-id: 299-fix-prevent-ruff-from-pruning-tool-imports-in-main