### PR TITLE
[fix] Correct spelling for uv dev dependencies

### DIFF
--- a/codemcp/templates/python/pyproject.toml
+++ b/codemcp/templates/python/pyproject.toml
@@ -11,14 +11,6 @@ dependencies = []
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[dependency-groups]
-dev = [
-    "pytest>=8.3.5",
-    "ruff>=0.11.2",
-    "pytest-xdist>=3.6.1",
-    "pyright>=1.1.350",
-]
-
 [tool.pytest.ini_options]
 addopts = "-n auto --tb=native"
 
@@ -45,3 +37,11 @@ reportIncompatibleMethodOverride = true
 
 [tool.ruff]
 target-version = "py312"
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=8.3.5",
+    "ruff>=0.11.2",
+    "pytest-xdist>=3.6.1",
+    "pyright>=1.1.350",
+]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #308
* #307
* #306
* __->__ #305

Signed-off-by: Edward Z. Yang <ezyang@meta.com>