### PR TITLE
fix: Replace buggy append_metadata_to_message implementation

### DIFF
--- a/codemcp/git_message.py
+++ b/codemcp/git_message.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import subprocess
 
 from .git_parse_message import parse_message
 
@@ -23,29 +22,10 @@ def append_metadata_to_message(message: str, metadata: dict[str, str]) -> str:
     Returns:
         The updated commit message with trailers added
     """
-    # Ensure there's a blank line before trailers if the message doesn't end with one
-    processed_message = message
-    if message and not message.endswith("\n\n"):
-        if message.endswith("\n"):
-            processed_message = message + "\n"
-        else:
-            processed_message = message + "\n\n"
+    from .git_parse_message import interpret_trailers
 
-    result = subprocess.check_output(
-        [
-            "git",
-            "interpret-trailers",
-            *[f"--trailer={k}: {v}" for k, v in metadata.items()],
-        ],
-        input=processed_message.encode("utf-8"),
-    ).decode("utf-8")
-
-    # git interpret-trailers adds a trailing newline that we need to handle properly
-    # Remove one trailing newline if there are multiple
-    if result.endswith("\n\n"):
-        result = result[:-1]
-
-    return result
+    trailers_to_add = [f"{k}: {v}" for k, v in metadata.items()]
+    return interpret_trailers(message, trailers_to_add)
 
 
 def update_commit_message_with_description(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #308
* #307
* #306
* #305

The implementation of append_metadata_to_message is a bit buggy and it is failing tests

FAILED tests/test_git_message.py::**TestGitMessageHandling::test_append_to_message_with_trailing_newlines** - AssertionError: 'feat: Add feature\n\nDescription\n\ncodemcp-id: abc-123\n\n' != 'feat: Add feature\n\nDescri...
FAILED tests/test_git_message.py::**TestGitMessageHandling::test_append_to_message_with_double_trailing_newlines** - AssertionError: 'feat: Add feature\n\nDescription\n\ncodemcp-id: abc-123\n\n\n' != 'feat: Add feature\n\nDesc...

Here is a better impl attached, please slot it in.

```git-revs
940b906  (Base revision)
a04e927  Add git_parse_message module with improved trailer parsing implementation
8ec84ca  Replace buggy append_metadata_to_message implementation with improved version
6249c20  Remove subprocess import from git_message.py since we're no longer using git interpret-trailers
513ae0f  Fix interpret_trailers to handle trailing newlines properly based on original message structure
4a9f30d  Fix trailer insertion logic to avoid adding extra newlines by using correct spacing
7e993e1  Rewrite interpret_trailers to follow the expected behavior from tests
927a645  Fix spacing for messages without body - they need single newline not double
7d00495  Fix empty message case to match expected format
f578782  Fix empty message case by handling it as a special case with correct spacing
HEAD     Skip the trailing newline logic for empty messages since we handle it specially
```

codemcp-id: 2-fix-replace-buggy-append-metadata-to-message-imple