### PR TITLE
docs: add MCP Find directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ codemcp fully obsolete.  However, there are some good design ideas (especially a
 the Git-versioning scheme) that I eventually want to port into the current generation
 of agentic coding clis.
 
+[![Listed on MCP Find](https://img.shields.io/badge/MCP_Find-Listed-blue)](https://mcp-find.org/tools/codemcp)
+
+
 # codemcp
 
 Make Claude Desktop a pair programming assistant by installing codemcp.  With


### PR DESCRIPTION
Hi 👋

codemcp is featured on [MCP Find](https://mcp-find.org/tools/codemcp), 
a curated directory for the MCP ecosystem. The listing includes an 
editorial review, evidence profile, trust signals, and related 
tool comparisons.

This PR adds a small badge linking to the listing page.

**What MCP Find provides for codemcp:**
- Dedicated tool profile with editorial review
- Trust/risk signal assessment  
- Comparison pages with related tools
- Integration into topic hubs (Coding cluster)
- Related workflow and learning guide links

Feel free to merge, modify placement, or close if you'd prefer 
not to include it. No pressure at all!

Preview: [codemcp on MCP Find](https://mcp-find.org/tools/codemcp)